### PR TITLE
ci: fix detect change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,14 @@ jobs:
       - name: Check changed files
         id: check_files
         run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          # Get parent of merge commit
+          MERGE_PARENT=$(git rev-parse ${{ github.event.pull_request.merge_commit_sha }}^)
+          CHANGED_FILES=$(git diff --name-only $MERGE_PARENT ${{ github.event.pull_request.merge_commit_sha }})
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No changed files detected, assuming kustomization only"
+            echo "only_kustomization=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           ONLY_KUSTOMIZATION=true
           for file in $CHANGED_FILES; do
             if [ "$file" != "config/manager/kustomization.yaml" ]; then
@@ -40,6 +47,7 @@ jobs:
             fi
           done
           echo "only_kustomization=$ONLY_KUSTOMIZATION" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Exit if only kustomization.yaml changed
         if: steps.check_files.outputs.only_kustomization == 'true'


### PR DESCRIPTION
## Summary by Sourcery

Correct the workflow for detecting changed files in the release CI pipeline by using the merge commit parent, logging SHA values, and safely handling cases with no changes.

CI:
- Fix change detection logic in release workflow by diffing merge commit parent to merge commit
- Add debug step to output merge commit and base SHA values
- Handle empty diff scenarios by defaulting to only_kustomization flag
- Set Bash as the shell for the file-checking step