### PR TITLE
chore: generate deployment manifest

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/siutsin/heartbeats
-  newTag: v0.3.0@sha256:c58fa37751d1c848dff90afe7fb8ac5fc540b51de2a64d2cc804b7d11909dd42
+  newTag: v0.4.0

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -421,7 +421,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: ghcr.io/siutsin/heartbeats:v0.3.0
+        image: ghcr.io/siutsin/heartbeats:v0.4.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary by Sourcery

Update deployment manifests to use the v0.4.0 controller image tag

Chores:
- Bump controller image tag to v0.4.0 in config/manager kustomization.yaml
- Update controller image reference to v0.4.0 in dist/install.yaml