### PR TITLE
feat: Add health check reporting

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Running Test e2e
         run: |
           go mod tidy
-          make test-e2e
+          make test-e2e-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Running Tests
         run: |
           go mod tidy
-          make test
+          make test-ci

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
     "default": true,
     "MD013": {
-        "line_length": 120
+        "line_length": 180
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,20 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet setup-envtest ## Run tests.
+test: manifests generate fmt vet setup-envtest ## Run unit tests without race detection (local development).
 	CGO_ENABLED=0 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./internal/... -coverprofile cover.out
 
-# TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
-# The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
-.PHONY: test-e2e
-test-e2e: manifests generate fmt vet docker-build ## Run the e2e tests. Use LOCAL=true for fresh kind cluster.
+.PHONY: test-ci
+test-ci: manifests generate fmt vet setup-envtest ## Run unit tests with race detection for CI.
+	CGO_ENABLED=1 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./internal/... -coverprofile cover.out
+
+# Shared function for e2e test setup and teardown
+# This eliminates duplication between test-e2e and test-e2e-ci targets
+# Parameters:
+#   $1 - CGO_ENABLED value (0 for local, 1 for CI)
+#   $2 - Test description for logging
+#   $3 - Additional go test flags (e.g., -race for CI)
+define run-e2e-tests
 	@command -v $(KIND) >/dev/null 2>&1 || { \
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
@@ -75,13 +80,28 @@ test-e2e: manifests generate fmt vet docker-build ## Run the e2e tests. Use LOCA
 		kind delete cluster --name kind; \
 		kind create cluster --name kind --config test/e2e/kind-config.yaml; \
 	fi
-	@echo "Running e2e tests..."
-	CGO_ENABLED=0 go test -race ./test/e2e/ -v -ginkgo.v
+	@echo "$(2)..."
+	CGO_ENABLED=$(1) go test $(3) ./test/e2e/ -v -ginkgo.v
 	@echo "Reverting kustomization file changes..."
 	@git checkout config/manager/kustomization.yaml
 	@if [ "$(LOCAL)" = "true" ]; then \
 		kind delete cluster --name kind; \
 	fi
+endef
+
+# TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
+# The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# CertManager is installed by default; skip with:
+# - CERT_MANAGER_INSTALL_SKIP=true
+.PHONY: test-e2e
+test-e2e: manifests generate fmt vet docker-build ## Run e2e tests without race detection (local development). Use LOCAL=true for fresh kind cluster.
+	$(call run-e2e-tests,0,Running e2e tests,)
+
+.PHONY: test-e2e-ci
+test-e2e-ci: manifests generate fmt vet docker-build ## Run e2e tests with race detection for CI. Use LOCAL=true for fresh kind cluster.
+	$(call run-e2e-tests,1,Running e2e tests with race detection,-race)
+
+##@ Linting
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
@@ -94,6 +114,24 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 .PHONY: lint-config
 lint-config: golangci-lint ## Verify golangci-lint linter configuration
 	$(GOLANGCI_LINT) config verify
+
+# Install markdownlint
+.PHONY: lint-markdown-install
+lint-markdown-install: ## Install markdownlint-cli2 for markdown linting
+	@echo "Installing markdownlint-cli2..."
+	brew install markdownlint-cli2
+
+# Lint markdown files
+.PHONY: lint-markdown
+lint-markdown: ## Lint markdown files using markdownlint-cli2
+	@echo "Linting markdown files..."
+	markdownlint-cli2 '**/*.md'
+
+# Fix markdown files
+.PHONY: lint-markdown-fix
+lint-markdown-fix: ## Fix markdown files using markdownlint-cli2
+	@echo "Fixing markdown files..."
+	markdownlint-cli2 '**/*.md' --fix
 
 ##@ Build
 
@@ -228,21 +266,3 @@ mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)
 endef
-
-# Install markdownlint
-.PHONY: lint-markdown-install
-lint-markdown-install:
-	@echo "Installing markdownlint-cli2..."
-	brew install markdownlint-cli2
-
-# Lint markdown files
-.PHONY: lint-markdown
-lint-markdown:
-	@echo "Linting markdown files..."
-	markdownlint-cli2 '**/*.md'
-
-# Fix markdown files
-.PHONY: lint-markdown-fix
-lint-markdown-fix:
-	@echo "Fixing markdown files..."
-	markdownlint-cli2 '**/*.md' --fix

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,9 @@
 
 ## Reporting a Vulnerability
 
-Hi, this project is intended for use in my personal Kubernetes home lab. If you spot any vulnerabilities, please feel free to [contact me](https://keys.openpgp.org/search?q=B5523C06213E516653CAD6344F5807ABAD36FF00) — much appreciated.
+Hi, this project is intended for use in my personal Kubernetes home lab. If you spot any vulnerabilities,
+please feel free to [contact me](https://keys.openpgp.org/search?q=B5523C06213E516653CAD6344F5807ABAD36FF00) —
+much appreciated.
 
-If you happen to be around London, UK, I would be glad to meet you personally to say thank you, and hopefully buy you a few drinks or coffee.
+If you happen to be around London, UK, I would be glad to meet you personally to say thank you, and
+hopefully buy you a few drinks or coffee.

--- a/api/v1alpha1/heartbeat_types.go
+++ b/api/v1alpha1/heartbeat_types.go
@@ -111,6 +111,9 @@ type HeartbeatStatus struct {
 
 	// LastChecked is the timestamp of the last health check
 	LastChecked *metav1.Time `json:"lastChecked,omitempty"`
+
+	// ReportStatus indicates if the last report (to healthy/unhealthy endpoint) was successful
+	ReportStatus string `json:"reportStatus,omitempty"`
 }
 
 // String returns a human-readable representation of the status

--- a/api/v1alpha1/heartbeat_types.go
+++ b/api/v1alpha1/heartbeat_types.go
@@ -62,6 +62,18 @@ type EndpointsSecret struct {
 	// UnhealthyEndpointKey is the key in the secret that contains the unhealthy endpoint URL
 	// +kubebuilder:validation:Required
 	UnhealthyEndpointKey string `json:"unhealthyEndpointKey"`
+
+	// HealthyEndpointMethod is the HTTP method to use when reporting to the healthy endpoint
+	// +kubebuilder:validation:Enum=GET;POST;PUT;PATCH
+	// +kubebuilder:default=GET
+	// +optional
+	HealthyEndpointMethod string `json:"healthyEndpointMethod,omitempty"`
+
+	// UnhealthyEndpointMethod is the HTTP method to use when reporting to the unhealthy endpoint
+	// +kubebuilder:validation:Enum=GET;POST;PUT;PATCH
+	// +kubebuilder:default=GET
+	// +optional
+	UnhealthyEndpointMethod string `json:"unhealthyEndpointMethod,omitempty"`
 }
 
 // StatusCodeRange defines a range of HTTP status codes

--- a/config/crd/bases/monitoring.siutsin.com_heartbeats.yaml
+++ b/config/crd/bases/monitoring.siutsin.com_heartbeats.yaml
@@ -118,6 +118,10 @@ spec:
                 description: Message contains a human-readable message about the endpoint
                   status
                 type: string
+              reportStatus:
+                description: ReportStatus indicates if the last report (to healthy/unhealthy
+                  endpoint) was successful
+                type: string
             required:
             - healthy
             - lastStatus

--- a/config/crd/bases/monitoring.siutsin.com_heartbeats.yaml
+++ b/config/crd/bases/monitoring.siutsin.com_heartbeats.yaml
@@ -47,6 +47,16 @@ spec:
                     description: HealthyEndpointKey is the key in the secret that
                       contains the healthy endpoint URL
                     type: string
+                  healthyEndpointMethod:
+                    default: GET
+                    description: HealthyEndpointMethod is the HTTP method to use when
+                      reporting to the healthy endpoint
+                    enum:
+                    - GET
+                    - POST
+                    - PUT
+                    - PATCH
+                    type: string
                   name:
                     description: Name of the secret
                     type: string
@@ -61,6 +71,16 @@ spec:
                   unhealthyEndpointKey:
                     description: UnhealthyEndpointKey is the key in the secret that
                       contains the unhealthy endpoint URL
+                    type: string
+                  unhealthyEndpointMethod:
+                    default: GET
+                    description: UnhealthyEndpointMethod is the HTTP method to use
+                      when reporting to the unhealthy endpoint
+                    enum:
+                    - GET
+                    - POST
+                    - PUT
+                    - PATCH
                     type: string
                 required:
                 - healthyEndpointKey

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 godebug default=go1.24
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/goccy/go-yaml v1.18.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
@@ -27,7 +28,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -2,15 +2,24 @@ package controller
 
 import "time"
 
-// Config holds the controller configuration
+// Config holds the controller configuration parameters.
+// It defines timeouts, retry settings, and requeue intervals for the heartbeat controller.
 type Config struct {
-	DefaultTimeout time.Duration
-	MaxRetries     int
-	RetryDelay     time.Duration
-	RequeueAfter   time.Duration
+	DefaultTimeout time.Duration // Maximum time to wait for HTTP requests
+	MaxRetries     int           // Maximum number of retry attempts for failed requests
+	RetryDelay     time.Duration // Delay between retry attempts
+	RequeueAfter   time.Duration // How often to requeue reconciliation
 }
 
-// DefaultConfig returns the default configuration
+// DefaultConfig returns the default configuration for the heartbeat controller.
+// This provides sensible defaults for production use.
+//
+// Returns:
+//   - Config: A configuration struct with default values:
+//   - DefaultTimeout: 10 seconds for HTTP requests
+//   - MaxRetries: 3 retry attempts
+//   - RetryDelay: 1 second between retries
+//   - RequeueAfter: 5 seconds between reconciliations
 func DefaultConfig() Config {
 	return Config{
 		DefaultTimeout: 10 * time.Second,

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/siutsin/heartbeats/internal/controller"
 )
 
+// TestDefaultConfig verifies that the default configuration returns the expected values.
+// This test ensures that the default configuration provides sensible defaults for production use.
+// It checks that all configuration fields have the correct default values.
 func TestDefaultConfig(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/internal/controller/errors.go
+++ b/internal/controller/errors.go
@@ -1,17 +1,53 @@
 package controller
 
-// Error messages
+// Error messages used throughout the controller for consistent error reporting.
+// These constants provide standardised error messages for various failure scenarios.
 const (
-	ErrFailedToCreateRequest  = "failed to create request"
-	ErrFailedToMakeRequest    = "failed to make request after maximum attempts"
-	ErrFailedToGetSecret      = "failed to get secret"
-	ErrMissingRequiredKey     = "missing required key"
-	ErrEndpointTimeout        = "endpoint timed out"
-	ErrFailedToCheckEndpoint  = "failed to check endpoint health"
+	// ErrFailedToCreateRequest indicates that an HTTP request could not be created.
+	// This typically occurs when the endpoint URL is malformed or invalid.
+	ErrFailedToCreateRequest = "failed to create request"
+
+	// ErrFailedToMakeRequest indicates that an HTTP request failed after maximum retry attempts.
+	// This includes network errors, connection refused, DNS resolution failures, etc.
+	ErrFailedToMakeRequest = "failed to make request after maximum attempts"
+
+	// ErrFailedToGetSecret indicates that a Kubernetes secret could not be retrieved.
+	// This occurs when the secret doesn't exist or the controller lacks permissions.
+	ErrFailedToGetSecret = "failed to get secret"
+
+	// ErrMissingRequiredKey indicates that a required key is missing from a Kubernetes secret.
+	// This happens when the secret exists but doesn't contain the expected endpoint keys.
+	ErrMissingRequiredKey = "missing required key"
+
+	// ErrEndpointTimeout indicates that an endpoint request timed out.
+	// This occurs when the endpoint takes longer than the configured timeout to respond.
+	ErrEndpointTimeout = "endpoint timed out"
+
+	// ErrFailedToCheckEndpoint indicates that the health check process failed.
+	// This is a general error for any failure during endpoint health checking.
+	ErrFailedToCheckEndpoint = "failed to check endpoint health"
+
+	// ErrInvalidStatusCodeRange indicates that a status code range has invalid min/max values.
+	// This occurs when the minimum value is greater than the maximum value.
 	ErrInvalidStatusCodeRange = "invalid status code range"
-	ErrFailedToUpdateStatus   = "failed to update Heartbeat status"
-	ErrEmptyEndpoint          = "endpoint URL is empty"
-	ErrStatusCodeNotInRange   = "status code is not within expected ranges"
-	ErrEndpointHealthy        = "endpoint is healthy"
-	ErrEndpointNotSpecified   = "endpoint is not specified"
+
+	// ErrFailedToUpdateStatus indicates that the Heartbeat status could not be updated.
+	// This occurs when there are permission issues or the resource has been modified.
+	ErrFailedToUpdateStatus = "failed to update Heartbeat status"
+
+	// ErrEmptyEndpoint indicates that an endpoint URL is empty or not specified.
+	// This occurs when the secret contains an empty string for an endpoint key.
+	ErrEmptyEndpoint = "endpoint URL is empty"
+
+	// ErrStatusCodeNotInRange indicates that the endpoint returned a status code outside expected ranges.
+	// This occurs when the endpoint is healthy but returns an unexpected status code.
+	ErrStatusCodeNotInRange = "status code is not within expected ranges"
+
+	// ErrEndpointHealthy indicates that the endpoint is healthy and responding correctly.
+	// This is a success message indicating the endpoint passed all health checks.
+	ErrEndpointHealthy = "endpoint is healthy"
+
+	// ErrEndpointNotSpecified indicates that an endpoint URL is not specified.
+	// This occurs when the endpoint key is missing from the secret.
+	ErrEndpointNotSpecified = "endpoint is not specified"
 )

--- a/internal/controller/health_checker.go
+++ b/internal/controller/health_checker.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -10,10 +9,12 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/go-logr/logr"
 	monitoringv1alpha1 "github.com/siutsin/heartbeats/api/v1alpha1"
 )
 
-// HealthChecker is an interface for checking endpoint health
+// HealthChecker is an interface for checking endpoint health.
+// Implementations should provide a method to check the health of an endpoint given expected status code ranges.
 type HealthChecker interface {
 	CheckEndpointHealth(
 		ctx context.Context,
@@ -22,42 +23,48 @@ type HealthChecker interface {
 	) (bool, int, error)
 }
 
-// DefaultHealthChecker is the default implementation of HealthChecker
+// DefaultHealthChecker is the default implementation of HealthChecker.
+// It uses HTTP requests and configurable retry logic to check endpoint health.
 type DefaultHealthChecker struct {
 	config Config
 }
 
-// NewHealthChecker creates a new DefaultHealthChecker
+// NewHealthChecker creates a new DefaultHealthChecker with the provided configuration.
+// Returns a HealthChecker interface.
 func NewHealthChecker(config Config) HealthChecker {
 	return &DefaultHealthChecker{
 		config: config,
 	}
 }
 
-// CheckEndpointHealth checks if the endpoint is healthy by making an HTTP request
-func (h *DefaultHealthChecker) CheckEndpointHealth(
-	ctx context.Context,
-	endpoint string,
-	expectedStatusCodeRanges []monitoringv1alpha1.StatusCodeRange,
-) (bool, int, error) {
-	log := log.FromContext(ctx)
+// createRequest creates a new HTTP GET request with the provided context and endpoint URL.
+// Returns the constructed *http.Request or an error if the request could not be created.
+func createRequest(ctx context.Context, endpoint string) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+}
 
-	client := &http.Client{
-		Timeout: h.config.DefaultTimeout,
+// isStatusCodeInRange checks if the given status code is within any of the provided expected ranges.
+// Returns true if the status code is in range, false otherwise.
+func isStatusCodeInRange(statusCode int, ranges []monitoringv1alpha1.StatusCodeRange) bool {
+	for _, r := range ranges {
+		if statusCode >= r.Min && statusCode <= r.Max {
+			return true
+		}
 	}
+	return false
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		log.Error(err, ErrFailedToCreateRequest, "endpoint", endpoint)
-		return false, 0, fmt.Errorf("%s: %w", ErrFailedToCreateRequest, err)
-	}
-
+// doRequestWithRetries performs the HTTP request with retry logic.
+// It attempts the request up to MaxRetries times, handling timeouts and network errors.
+// Returns the HTTP response or the last error encountered.
+func (h *DefaultHealthChecker) doRequestWithRetries(req *http.Request, log logr.Logger) (*http.Response, error) {
 	var lastErr error
+	client := &http.Client{Timeout: h.config.DefaultTimeout}
 	for i := 0; i < h.config.MaxRetries; i++ {
 		resp, err := client.Do(req)
 		if err != nil {
-			log.Error(err, "Failed to make request", "endpoint", endpoint, "attempt", i+1)
-			if err, ok := err.(net.Error); ok && err.Timeout() {
+			log.Error(err, "Failed to make request", "endpoint", req.URL.String(), "attempt", i+1)
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				log.Error(err, ErrEndpointTimeout, "timeout", h.config.DefaultTimeout)
 				lastErr = fmt.Errorf("%s: %w", ErrEndpointTimeout, err)
 			} else {
@@ -66,26 +73,48 @@ func (h *DefaultHealthChecker) CheckEndpointHealth(
 			time.Sleep(h.config.RetryDelay)
 			continue
 		}
-		if resp != nil {
-			defer func() {
-				if err := resp.Body.Close(); err != nil {
-					log.Error(err, "Failed to close response body")
-				}
-			}()
-		}
+		return resp, nil
+	}
+	return nil, lastErr
+}
 
-		for _, r := range expectedStatusCodeRanges {
-			if resp.StatusCode >= r.Min && resp.StatusCode <= r.Max {
-				return true, resp.StatusCode, nil
+// CheckEndpointHealth checks if the endpoint is healthy by making an HTTP request.
+//
+// Returns:
+//
+//	bool:  true if the endpoint is considered healthy (status code in expected range), false otherwise.
+//	int:   the HTTP status code returned by the endpoint, or 0 if no response was received.
+//	error: non-nil if an error occurred during the health check (e.g., network error, timeout, invalid request),
+//	       or nil if the check was successful.
+//
+// This allows the caller to distinguish between healthy/unhealthy endpoints, inspect the actual status code,
+// and handle errors in an idiomatic Go way.
+func (h *DefaultHealthChecker) CheckEndpointHealth(
+	ctx context.Context,
+	endpoint string,
+	expectedStatusCodeRanges []monitoringv1alpha1.StatusCodeRange) (bool, int, error) {
+	log := log.FromContext(ctx)
+
+	req, err := createRequest(ctx, endpoint)
+	if err != nil {
+		log.Error(err, ErrFailedToCreateRequest, "endpoint", endpoint)
+		return false, 0, fmt.Errorf("%s: %w", ErrFailedToCreateRequest, err)
+	}
+
+	resp, err := h.doRequestWithRetries(req, log)
+	if err != nil {
+		return false, 0, err
+	}
+	if resp != nil {
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				log.Error(err, "Failed to close response body")
 			}
-		}
-		return false, resp.StatusCode, nil
+		}()
 	}
 
-	if lastErr != nil {
-		return false, 0, lastErr
+	if isStatusCodeInRange(resp.StatusCode, expectedStatusCodeRanges) {
+		return true, resp.StatusCode, nil
 	}
-
-	log.Error(nil, ErrFailedToMakeRequest, "attempts", h.config.MaxRetries)
-	return false, 0, errors.New(ErrFailedToMakeRequest)
+	return false, resp.StatusCode, nil
 }

--- a/internal/controller/health_checker_test.go
+++ b/internal/controller/health_checker_test.go
@@ -20,7 +20,7 @@ const (
 	testRequeueTime = 3 * time.Second
 )
 
-// Test assertion messages
+// Test assertion messages used throughout the test suite for consistent error reporting.
 const (
 	errNilChecker          = "health checker should not be nil"
 	errConfigMismatch      = "config should match"
@@ -32,6 +32,8 @@ const (
 	errMessageMismatch     = "error message mismatch"
 )
 
+// TestNewHealthChecker verifies that a new health checker can be created with the provided configuration.
+// This test ensures the factory function works correctly and returns a non-nil instance.
 func TestNewHealthChecker(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -46,20 +48,18 @@ func TestNewHealthChecker(t *testing.T) {
 	g.Expect(checker).NotTo(gomega.BeNil(), errNilChecker)
 }
 
-func TestCheckEndpointHealth(t *testing.T) {
+// TestCheckEndpointHealth_HealthyEndpoint tests health checking for healthy endpoints.
+// It verifies that endpoints returning status codes within expected ranges are marked as healthy.
+func TestCheckEndpointHealth_HealthyEndpoint(t *testing.T) {
 	tests := []struct {
 		name           string
 		statusCode     int
 		expectedRange  []monitoringv1alpha1.StatusCodeRange
-		expectHealthy  bool
-		expectError    bool
-		expectedErrMsg string
 		serverBehavior func(http.ResponseWriter, *http.Request)
 	}{
 		{
-			name:          "healthy endpoint within range",
-			statusCode:    http.StatusOK,
-			expectHealthy: true,
+			name:       "healthy endpoint within range",
+			statusCode: http.StatusOK,
 			expectedRange: []monitoringv1alpha1.StatusCodeRange{
 				{Min: 200, Max: 299},
 			},
@@ -68,20 +68,8 @@ func TestCheckEndpointHealth(t *testing.T) {
 			},
 		},
 		{
-			name:          "unhealthy endpoint outside range",
-			statusCode:    http.StatusInternalServerError,
-			expectHealthy: false,
-			expectedRange: []monitoringv1alpha1.StatusCodeRange{
-				{Min: 200, Max: 299},
-			},
-			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
-			},
-		},
-		{
-			name:          "multiple status code ranges",
-			statusCode:    http.StatusAccepted,
-			expectHealthy: true,
+			name:       "multiple status code ranges",
+			statusCode: http.StatusAccepted,
 			expectedRange: []monitoringv1alpha1.StatusCodeRange{
 				{Min: 200, Max: 204},
 				{Min: 300, Max: 399},
@@ -91,74 +79,8 @@ func TestCheckEndpointHealth(t *testing.T) {
 			},
 		},
 		{
-			name:           "server timeout",
-			expectHealthy:  false,
-			expectError:    true,
-			expectedErrMsg: controller.ErrEndpointTimeout,
-			expectedRange: []monitoringv1alpha1.StatusCodeRange{
-				{Min: 200, Max: 299},
-			},
-			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
-				time.Sleep(2 * time.Second)
-				w.WriteHeader(http.StatusOK)
-			},
-		},
-		{
-			name:          "empty status code ranges",
-			statusCode:    http.StatusOK,
-			expectHealthy: false,
-			expectedRange: []monitoringv1alpha1.StatusCodeRange{},
-			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			},
-		},
-		{
-			name:           "invalid URL",
-			expectHealthy:  false,
-			expectError:    true,
-			expectedErrMsg: controller.ErrFailedToCreateRequest,
-			expectedRange: []monitoringv1alpha1.StatusCodeRange{
-				{Min: 200, Max: 299},
-			},
-			serverBehavior: nil, // No server needed for invalid URL test
-		},
-		{
-			name:           "connection refused",
-			expectHealthy:  false,
-			expectError:    true,
-			expectedErrMsg: controller.ErrFailedToMakeRequest,
-			expectedRange: []monitoringv1alpha1.StatusCodeRange{
-				{Min: 200, Max: 299},
-			},
-			serverBehavior: nil, // No server needed for connection refused test
-		},
-		{
-			name:           "DNS error",
-			expectHealthy:  false,
-			expectError:    true,
-			expectedErrMsg: controller.ErrFailedToMakeRequest,
-			expectedRange: []monitoringv1alpha1.StatusCodeRange{
-				{Min: 200, Max: 299},
-			},
-			serverBehavior: nil, // No server needed for DNS error test
-		},
-		{
-			name:           "context cancelled",
-			expectHealthy:  false,
-			expectError:    true,
-			expectedErrMsg: controller.ErrEndpointTimeout,
-			expectedRange: []monitoringv1alpha1.StatusCodeRange{
-				{Min: 200, Max: 299},
-			},
-			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
-				time.Sleep(500 * time.Millisecond)
-				w.WriteHeader(http.StatusOK)
-			},
-		},
-		{
-			name:          "overlapping ranges",
-			statusCode:    http.StatusOK,
-			expectHealthy: true,
+			name:       "overlapping ranges",
+			statusCode: http.StatusOK,
 			expectedRange: []monitoringv1alpha1.StatusCodeRange{
 				{Min: 200, Max: 299},
 				{Min: 250, Max: 350},
@@ -168,9 +90,8 @@ func TestCheckEndpointHealth(t *testing.T) {
 			},
 		},
 		{
-			name:          "boundary test - min",
-			statusCode:    http.StatusOK,
-			expectHealthy: true,
+			name:       "boundary test - min",
+			statusCode: http.StatusOK,
 			expectedRange: []monitoringv1alpha1.StatusCodeRange{
 				{Min: 200, Max: 200},
 			},
@@ -179,9 +100,8 @@ func TestCheckEndpointHealth(t *testing.T) {
 			},
 		},
 		{
-			name:          "boundary test - max",
-			statusCode:    http.StatusMultipleChoices,
-			expectHealthy: true,
+			name:       "boundary test - max",
+			statusCode: http.StatusMultipleChoices,
 			expectedRange: []monitoringv1alpha1.StatusCodeRange{
 				{Min: 300, Max: 300},
 			},
@@ -190,9 +110,8 @@ func TestCheckEndpointHealth(t *testing.T) {
 			},
 		},
 		{
-			name:          "response with body",
-			statusCode:    http.StatusOK,
-			expectHealthy: true,
+			name:       "response with body",
+			statusCode: http.StatusOK,
 			expectedRange: []monitoringv1alpha1.StatusCodeRange{
 				{Min: 200, Max: 299},
 			},
@@ -208,23 +127,8 @@ func TestCheckEndpointHealth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
-			var server *httptest.Server
-			var endpoint string
-
-			if tt.serverBehavior != nil {
-				server = httptest.NewServer(http.HandlerFunc(tt.serverBehavior))
-				defer server.Close()
-				endpoint = server.URL
-			} else {
-				switch tt.name {
-				case "invalid URL":
-					endpoint = "http://invalid-url:invalid-port"
-				case "connection refused":
-					endpoint = "http://localhost:9999" // Assuming this port is not in use
-				case "DNS error":
-					endpoint = "http://nonexistent-domain-that-does-not-exist.com"
-				}
-			}
+			server := httptest.NewServer(http.HandlerFunc(tt.serverBehavior))
+			defer server.Close()
 
 			checker := controller.NewHealthChecker(controller.Config{
 				DefaultTimeout: testTimeout,
@@ -232,34 +136,192 @@ func TestCheckEndpointHealth(t *testing.T) {
 				RetryDelay:     testRetryDelay,
 			})
 
-			ctx := context.Background()
-			if tt.name == "context cancelled" {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, 100*time.Millisecond)
-				defer cancel()
-			}
-
 			healthy, statusCode, _, err := checker.CheckEndpointHealth(
-				ctx,
-				endpoint,
+				context.Background(),
+				server.URL,
 				tt.expectedRange,
 				monitoringv1alpha1.EndpointsSecret{}, // dummy for legacy tests
 			)
 
-			if tt.expectError {
-				g.Expect(err).To(gomega.HaveOccurred(), errExpectedError)
-				if tt.expectedErrMsg != "" {
-					g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectedErrMsg), errMessageMismatch)
-				}
-			} else {
-				g.Expect(err).NotTo(gomega.HaveOccurred(), errUnexpectedError)
-				g.Expect(healthy).To(gomega.Equal(tt.expectHealthy), errHealthyMismatch)
-				g.Expect(statusCode).To(gomega.Equal(tt.statusCode), errStatusCodeMismatch)
-			}
+			g.Expect(err).NotTo(gomega.HaveOccurred(), errUnexpectedError)
+			g.Expect(healthy).To(gomega.BeTrue(), errHealthyMismatch)
+			g.Expect(statusCode).To(gomega.Equal(tt.statusCode), errStatusCodeMismatch)
 		})
 	}
 }
 
+// TestCheckEndpointHealth_UnhealthyEndpoint tests health checking for unhealthy endpoints.
+// It verifies that endpoints returning status codes outside expected ranges are marked as unhealthy.
+func TestCheckEndpointHealth_UnhealthyEndpoint(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		expectedRange  []monitoringv1alpha1.StatusCodeRange
+		serverBehavior func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:       "unhealthy endpoint outside range",
+			statusCode: http.StatusInternalServerError,
+			expectedRange: []monitoringv1alpha1.StatusCodeRange{
+				{Min: 200, Max: 299},
+			},
+			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+		},
+		{
+			name:          "empty status code ranges",
+			statusCode:    http.StatusOK,
+			expectedRange: []monitoringv1alpha1.StatusCodeRange{},
+			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			server := httptest.NewServer(http.HandlerFunc(tt.serverBehavior))
+			defer server.Close()
+
+			checker := controller.NewHealthChecker(controller.Config{
+				DefaultTimeout: testTimeout,
+				MaxRetries:     testMaxRetries,
+				RetryDelay:     testRetryDelay,
+			})
+
+			healthy, statusCode, _, err := checker.CheckEndpointHealth(
+				context.Background(),
+				server.URL,
+				tt.expectedRange,
+				monitoringv1alpha1.EndpointsSecret{}, // dummy for legacy tests
+			)
+
+			g.Expect(err).NotTo(gomega.HaveOccurred(), errUnexpectedError)
+			g.Expect(healthy).To(gomega.BeFalse(), errHealthyMismatch)
+			g.Expect(statusCode).To(gomega.Equal(tt.statusCode), errStatusCodeMismatch)
+		})
+	}
+}
+
+// TestCheckEndpointHealth_NetworkErrors tests health checking when network errors occur.
+// It verifies that various network failure scenarios are handled correctly with appropriate error messages.
+func TestCheckEndpointHealth_NetworkErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		endpoint       string
+		expectedErrMsg string
+		serverBehavior func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:           "invalid URL",
+			endpoint:       "http://invalid-url:invalid-port",
+			expectedErrMsg: controller.ErrFailedToCreateRequest,
+		},
+		{
+			name:           "connection refused",
+			endpoint:       "http://localhost:9999", // Assuming this port is not in use
+			expectedErrMsg: controller.ErrFailedToMakeRequest,
+		},
+		{
+			name:           "DNS error",
+			endpoint:       "http://nonexistent-domain-that-does-not-exist.com",
+			expectedErrMsg: controller.ErrFailedToMakeRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			checker := controller.NewHealthChecker(controller.Config{
+				DefaultTimeout: testTimeout,
+				MaxRetries:     testMaxRetries,
+				RetryDelay:     testRetryDelay,
+			})
+
+			healthy, statusCode, _, err := checker.CheckEndpointHealth(
+				context.Background(),
+				tt.endpoint,
+				[]monitoringv1alpha1.StatusCodeRange{{Min: 200, Max: 299}},
+				monitoringv1alpha1.EndpointsSecret{}, // dummy for legacy tests
+			)
+
+			g.Expect(err).To(gomega.HaveOccurred(), errExpectedError)
+			g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectedErrMsg), errMessageMismatch)
+			g.Expect(healthy).To(gomega.BeFalse(), errHealthyMismatch)
+			g.Expect(statusCode).To(gomega.Equal(0), errStatusCodeMismatch)
+		})
+	}
+}
+
+// TestCheckEndpointHealth_TimeoutErrors tests health checking when timeout errors occur.
+// It verifies that timeout scenarios are handled correctly with appropriate error messages.
+func TestCheckEndpointHealth_TimeoutErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedErrMsg string
+		serverBehavior func(http.ResponseWriter, *http.Request)
+		setupContext   func() context.Context
+	}{
+		{
+			name:           "server timeout",
+			expectedErrMsg: controller.ErrEndpointTimeout,
+			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
+				time.Sleep(2 * time.Second)
+				w.WriteHeader(http.StatusOK)
+			},
+			setupContext: func() context.Context { return context.Background() },
+		},
+		{
+			name:           "context cancelled",
+			expectedErrMsg: "context canceled",
+			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
+				time.Sleep(500 * time.Millisecond)
+				w.WriteHeader(http.StatusOK)
+			},
+			setupContext: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				defer cancel()
+				return ctx
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			server := httptest.NewServer(http.HandlerFunc(tt.serverBehavior))
+			defer server.Close()
+
+			checker := controller.NewHealthChecker(controller.Config{
+				DefaultTimeout: testTimeout,
+				MaxRetries:     testMaxRetries,
+				RetryDelay:     testRetryDelay,
+			})
+
+			ctx := tt.setupContext()
+			healthy, statusCode, _, err := checker.CheckEndpointHealth(
+				ctx,
+				server.URL,
+				[]monitoringv1alpha1.StatusCodeRange{{Min: 200, Max: 299}},
+				monitoringv1alpha1.EndpointsSecret{}, // dummy for legacy tests
+			)
+
+			g.Expect(err).To(gomega.HaveOccurred(), errExpectedError)
+			g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectedErrMsg), errMessageMismatch)
+			g.Expect(healthy).To(gomega.BeFalse(), errHealthyMismatch)
+			g.Expect(statusCode).To(gomega.Equal(0), errStatusCodeMismatch)
+		})
+	}
+}
+
+// TestCheckEndpointHealth_ReportsToCorrectEndpoint tests that health status is reported to the correct endpoints.
+// It verifies that healthy endpoints report to the healthy endpoint and unhealthy endpoints report to the
+// unhealthy endpoint.
 func TestCheckEndpointHealth_ReportsToCorrectEndpoint(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/internal/controller/heartbeat_controller.go
+++ b/internal/controller/heartbeat_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,102 +49,267 @@ type HeartbeatReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop
 func (r *HeartbeatReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	// Step 1: Fetch the Heartbeat resource
+	heartbeat, err := r.fetchHeartbeat(ctx, req)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if heartbeat == nil {
+		// Heartbeat was deleted, nothing to reconcile
+		return ctrl.Result{}, nil
+	}
 
+	// Step 2: Fetch and validate the secret containing endpoints
+	secret, err := r.fetchAndValidateSecret(ctx, req, heartbeat)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+	}
+
+	// Step 3: Extract and validate the target endpoint
+	targetEndpoint, err := r.extractTargetEndpoint(ctx, heartbeat, secret)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+	}
+
+	// Step 4: Extract report endpoints for health status reporting
+	reportEndpointsSecret, err := r.extractReportEndpoints(ctx, heartbeat, secret)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+	}
+
+	// Step 5: Perform health check, validate ranges, and report status
+	if err := r.performHealthCheckAndReport(ctx, heartbeat, targetEndpoint, reportEndpointsSecret); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+}
+
+// fetchHeartbeat retrieves the Heartbeat resource from the cluster.
+// Returns nil if the resource was not found (deleted), or an error if the fetch failed.
+func (r *HeartbeatReconciler) fetchHeartbeat(
+	ctx context.Context,
+	req ctrl.Request,
+) (*monitoringv1alpha1.Heartbeat, error) {
 	var heartbeat monitoringv1alpha1.Heartbeat
 	if err := r.Get(ctx, req.NamespacedName, &heartbeat); err != nil {
 		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
+			return nil, nil // Resource was deleted
 		}
-		log.Error(err, ErrFailedToGetSecret)
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return nil, client.IgnoreNotFound(err)
 	}
+	return &heartbeat, nil
+}
 
-	// Get the endpoint from the secret
+// fetchAndValidateSecret retrieves the secret containing endpoint configuration.
+// Returns an error if the secret cannot be fetched, which will trigger status update and requeue.
+func (r *HeartbeatReconciler) fetchAndValidateSecret(
+	ctx context.Context,
+	req ctrl.Request,
+	heartbeat *monitoringv1alpha1.Heartbeat,
+) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secretNamespace := heartbeat.Spec.EndpointsSecret.Namespace
 	if secretNamespace == "" {
 		secretNamespace = req.Namespace
 	}
+
 	secretKey := client.ObjectKey{
 		Namespace: secretNamespace,
 		Name:      heartbeat.Spec.EndpointsSecret.Name,
 	}
+
 	if err := r.Get(ctx, secretKey, secret); err != nil {
-		if err := r.StatusUpdater.UpdateSecretErrorStatus(ctx, &heartbeat, err); err != nil {
-			return ctrl.Result{}, err
+		if err := r.StatusUpdater.UpdateSecretErrorStatus(ctx, heartbeat, err); err != nil {
+			return nil, err
 		}
-		return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+		return nil, err
 	}
 
+	return secret, nil
+}
+
+// extractTargetEndpoint extracts and validates the target endpoint URL from the secret.
+// Returns an error if the target endpoint key is missing or empty, which will trigger status update and requeue.
+func (r *HeartbeatReconciler) extractTargetEndpoint(
+	ctx context.Context,
+	heartbeat *monitoringv1alpha1.Heartbeat,
+	secret *corev1.Secret,
+) (string, error) {
 	endpointBytes, ok := secret.Data[heartbeat.Spec.EndpointsSecret.TargetEndpointKey]
 	if !ok {
 		if err := r.StatusUpdater.UpdateMissingKeyStatus(
 			ctx,
-			&heartbeat,
+			heartbeat,
 			heartbeat.Spec.EndpointsSecret.TargetEndpointKey,
 		); err != nil {
-			return ctrl.Result{}, err
+			return "", err
 		}
-		return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+		return "", fmt.Errorf(
+			"missing target endpoint key: %s",
+			heartbeat.Spec.EndpointsSecret.TargetEndpointKey,
+		)
 	}
 
 	endpoint := string(endpointBytes)
 	if endpoint == "" {
-		if err := r.StatusUpdater.UpdateEmptyEndpointStatus(ctx, &heartbeat); err != nil {
-			return ctrl.Result{}, err
+		if err := r.StatusUpdater.UpdateEmptyEndpointStatus(ctx, heartbeat); err != nil {
+			return "", err
 		}
-		return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+		return "", fmt.Errorf("target endpoint is empty")
 	}
 
-	// Check the endpoint health
-	healthy, statusCode, err := r.HealthChecker.CheckEndpointHealth(
-		ctx,
-		endpoint,
-		heartbeat.Spec.ExpectedStatusCodeRanges,
-	)
-	if err != nil {
-		if err := r.StatusUpdater.UpdateHealthCheckErrorStatus(
+	return endpoint, nil
+}
+
+// extractReportEndpoints extracts the healthy and unhealthy endpoint URLs from the secret for reporting.
+// Returns an error if either report endpoint key is missing, which will trigger status update and requeue.
+func (r *HeartbeatReconciler) extractReportEndpoints(
+	ctx context.Context,
+	heartbeat *monitoringv1alpha1.Heartbeat,
+	secret *corev1.Secret,
+) (monitoringv1alpha1.EndpointsSecret, error) {
+	// Extract healthy endpoint
+	healthyEndpointBytes, ok := secret.Data[heartbeat.Spec.EndpointsSecret.HealthyEndpointKey]
+	if !ok {
+		if err := r.StatusUpdater.UpdateMissingKeyStatus(
 			ctx,
-			&heartbeat,
-			statusCode,
-			err,
+			heartbeat,
+			heartbeat.Spec.EndpointsSecret.HealthyEndpointKey,
 		); err != nil {
-			return ctrl.Result{}, err
+			return monitoringv1alpha1.EndpointsSecret{}, err
 		}
-		return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+		return monitoringv1alpha1.EndpointsSecret{}, fmt.Errorf(
+			"missing healthy endpoint key: %s",
+			heartbeat.Spec.EndpointsSecret.HealthyEndpointKey,
+		)
 	}
 
-	// Check if any of the status code ranges are invalid
+	// Extract unhealthy endpoint
+	unhealthyEndpointBytes, ok := secret.Data[heartbeat.Spec.EndpointsSecret.UnhealthyEndpointKey]
+	if !ok {
+		if err := r.StatusUpdater.UpdateMissingKeyStatus(
+			ctx,
+			heartbeat,
+			heartbeat.Spec.EndpointsSecret.UnhealthyEndpointKey,
+		); err != nil {
+			return monitoringv1alpha1.EndpointsSecret{}, err
+		}
+		return monitoringv1alpha1.EndpointsSecret{}, fmt.Errorf(
+			"missing unhealthy endpoint key: %s",
+			heartbeat.Spec.EndpointsSecret.UnhealthyEndpointKey,
+		)
+	}
+
+	// Create EndpointsSecret with actual URLs for reporting
+	reportEndpointsSecret := monitoringv1alpha1.EndpointsSecret{
+		HealthyEndpointKey:   string(healthyEndpointBytes),
+		UnhealthyEndpointKey: string(unhealthyEndpointBytes),
+	}
+
+	return reportEndpointsSecret, nil
+}
+
+// performHealthCheckAndReport performs the actual health check and reports the status.
+// This is the core business logic that determines if the endpoint is healthy and reports accordingly.
+func (r *HeartbeatReconciler) performHealthCheckAndReport(
+	ctx context.Context,
+	heartbeat *monitoringv1alpha1.Heartbeat,
+	targetEndpoint string,
+	reportEndpointsSecret monitoringv1alpha1.EndpointsSecret,
+) error {
+	// Validate status code ranges before health check
+	if hasInvalidRange := r.validateStatusCodeRanges(ctx, heartbeat); hasInvalidRange {
+		return nil // Early return, status already updated
+	}
+
+	// Perform the health check
+	healthy, statusCode, reportSuccess, err := r.performHealthCheck(
+		ctx,
+		targetEndpoint,
+		heartbeat.Spec.ExpectedStatusCodeRanges,
+		reportEndpointsSecret,
+	)
+
+	if err != nil {
+		return r.handleHealthCheckError(ctx, heartbeat, statusCode, err)
+	}
+
+	// Update status with successful health check results
+	return r.updateHealthStatus(ctx, heartbeat, healthy, statusCode, reportSuccess)
+}
+
+// performHealthCheck executes the actual health check against the target endpoint.
+func (r *HeartbeatReconciler) performHealthCheck(
+	ctx context.Context,
+	targetEndpoint string,
+	expectedRanges []monitoringv1alpha1.StatusCodeRange,
+	reportEndpointsSecret monitoringv1alpha1.EndpointsSecret,
+) (bool, int, bool, error) {
+	return r.HealthChecker.CheckEndpointHealth(
+		ctx,
+		targetEndpoint,
+		expectedRanges,
+		reportEndpointsSecret,
+	)
+}
+
+// handleHealthCheckError updates the status with health check error information.
+func (r *HeartbeatReconciler) handleHealthCheckError(
+	ctx context.Context,
+	heartbeat *monitoringv1alpha1.Heartbeat,
+	statusCode int,
+	err error,
+) error {
+	if err := r.StatusUpdater.UpdateHealthCheckErrorStatus(
+		ctx,
+		heartbeat,
+		statusCode,
+		err,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateStatusCodeRanges validates that all status code ranges have valid min/max values.
+// Returns true if an invalid range was found and status was updated.
+func (r *HeartbeatReconciler) validateStatusCodeRanges(
+	ctx context.Context,
+	heartbeat *monitoringv1alpha1.Heartbeat,
+) bool {
 	for _, statusRange := range heartbeat.Spec.ExpectedStatusCodeRanges {
 		if statusRange.Min > statusRange.Max {
 			if err := r.StatusUpdater.UpdateInvalidRangeStatus(
 				ctx,
-				&heartbeat,
-				statusCode,
+				heartbeat,
+				0, // No status code available before health check
 			); err != nil {
-				return ctrl.Result{}, err
+				// Log error but don't fail the reconciliation
+				log.FromContext(ctx).Error(err, "Failed to update invalid range status")
 			}
-			return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+			return true // Invalid range found
 		}
 	}
+	return false // No invalid ranges found
+}
 
-	// Check if the status code is within any of the expected ranges
-	if isStatusCodeInRange(statusCode, heartbeat.Spec.ExpectedStatusCodeRanges) {
-		healthy = true
-	}
-
-	if err := r.StatusUpdater.UpdateHealthStatus(
+// updateHealthStatus updates the Heartbeat status with successful health check results.
+func (r *HeartbeatReconciler) updateHealthStatus(
+	ctx context.Context,
+	heartbeat *monitoringv1alpha1.Heartbeat,
+	healthy bool,
+	statusCode int,
+	reportSuccess bool,
+) error {
+	return r.StatusUpdater.UpdateHealthStatus(
 		ctx,
-		&heartbeat,
+		heartbeat,
 		healthy,
 		statusCode,
 		nil,
-	); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{RequeueAfter: r.Config.RequeueAfter}, nil
+		reportSuccess,
+	)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/heartbeat_controller.go
+++ b/internal/controller/heartbeat_controller.go
@@ -157,13 +157,3 @@ func (r *HeartbeatReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&monitoringv1alpha1.Heartbeat{}).
 		Complete(r)
 }
-
-// isStatusCodeInRange checks if the status code is within any of the expected ranges
-func isStatusCodeInRange(statusCode int, ranges []monitoringv1alpha1.StatusCodeRange) bool {
-	for _, r := range ranges {
-		if statusCode >= r.Min && statusCode <= r.Max {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/controller/status_updater.go
+++ b/internal/controller/status_updater.go
@@ -138,6 +138,7 @@ func (u *StatusUpdater) UpdateHealthStatus(
 	healthy bool,
 	statusCode int,
 	err error,
+	reportSuccess bool,
 ) error {
 	log := log.FromContext(ctx)
 
@@ -152,6 +153,12 @@ func (u *StatusUpdater) UpdateHealthStatus(
 		heartbeat.Status.Message = ErrEndpointHealthy
 	} else {
 		heartbeat.Status.Message = ErrStatusCodeNotInRange
+	}
+
+	if reportSuccess {
+		heartbeat.Status.ReportStatus = "Success"
+	} else {
+		heartbeat.Status.ReportStatus = "Failure"
 	}
 
 	if err := u.Client.Status().Update(ctx, heartbeat); err != nil {

--- a/internal/controller/status_updater.go
+++ b/internal/controller/status_updater.go
@@ -10,19 +10,38 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// StatusUpdater handles updating the status of Heartbeat resources
+// StatusUpdater handles updating the status of Heartbeat resources.
+// It provides methods for updating various aspects of the Heartbeat status
+// including health status, error conditions, and metadata.
 type StatusUpdater struct {
-	Client client.Client
+	Client client.Client // Kubernetes client for updating resources
 }
 
-// NewStatusUpdater creates a new StatusUpdater
+// NewStatusUpdater creates a new StatusUpdater instance with the provided Kubernetes client.
+//
+// Parameters:
+//   - client: The Kubernetes client used for updating Heartbeat resources
+//
+// Returns:
+//   - *StatusUpdater: A new StatusUpdater instance
 func NewStatusUpdater(client client.Client) *StatusUpdater {
 	return &StatusUpdater{
 		Client: client,
 	}
 }
 
-// UpdateStatus updates the status of a Heartbeat resource
+// UpdateStatus updates the status of a Heartbeat resource with the provided values.
+// This is the core method that all other status update methods use internally.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - heartbeat: The Heartbeat resource to update
+//   - statusCode: HTTP status code from the health check (0 if not applicable)
+//   - healthy: Whether the endpoint is considered healthy
+//   - message: Status message describing the current state
+//
+// Returns:
+//   - error: Non-nil if the status update failed, nil otherwise
 func (u *StatusUpdater) UpdateStatus(
 	ctx context.Context,
 	heartbeat *monitoringv1alpha1.Heartbeat,
@@ -46,7 +65,16 @@ func (u *StatusUpdater) UpdateStatus(
 	return nil
 }
 
-// UpdateSecretErrorStatus updates the status when there's an error with the secret
+// UpdateSecretErrorStatus updates the status when there's an error retrieving the secret.
+// This method logs the error and sets the status to indicate a secret-related failure.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - heartbeat: The Heartbeat resource to update
+//   - err: The error that occurred while retrieving the secret
+//
+// Returns:
+//   - error: Non-nil if the status update failed, nil otherwise
 func (u *StatusUpdater) UpdateSecretErrorStatus(
 	ctx context.Context,
 	heartbeat *monitoringv1alpha1.Heartbeat,
@@ -63,7 +91,16 @@ func (u *StatusUpdater) UpdateSecretErrorStatus(
 	)
 }
 
-// UpdateMissingKeyStatus updates the status when a required key is missing
+// UpdateMissingKeyStatus updates the status when a required key is missing from the secret.
+// This method logs the missing key and sets the status to indicate the configuration issue.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - heartbeat: The Heartbeat resource to update
+//   - key: The name of the missing key in the secret
+//
+// Returns:
+//   - error: Non-nil if the status update failed, nil otherwise
 func (u *StatusUpdater) UpdateMissingKeyStatus(
 	ctx context.Context,
 	heartbeat *monitoringv1alpha1.Heartbeat,
@@ -80,7 +117,15 @@ func (u *StatusUpdater) UpdateMissingKeyStatus(
 	)
 }
 
-// UpdateEmptyEndpointStatus updates the status when the endpoint is empty
+// UpdateEmptyEndpointStatus updates the status when the endpoint URL is empty.
+// This method logs the issue and sets the status to indicate an empty endpoint configuration.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - heartbeat: The Heartbeat resource to update
+//
+// Returns:
+//   - error: Non-nil if the status update failed, nil otherwise
 func (u *StatusUpdater) UpdateEmptyEndpointStatus(
 	ctx context.Context,
 	heartbeat *monitoringv1alpha1.Heartbeat,
@@ -96,7 +141,17 @@ func (u *StatusUpdater) UpdateEmptyEndpointStatus(
 	)
 }
 
-// UpdateHealthCheckErrorStatus updates the status when there's an error checking health
+// UpdateHealthCheckErrorStatus updates the status when there's an error during health checking.
+// This method logs the error and sets the status to indicate a health check failure.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - heartbeat: The Heartbeat resource to update
+//   - statusCode: HTTP status code if available (0 if not applicable)
+//   - err: The error that occurred during health checking
+//
+// Returns:
+//   - error: Non-nil if the status update failed, nil otherwise
 func (u *StatusUpdater) UpdateHealthCheckErrorStatus(
 	ctx context.Context,
 	heartbeat *monitoringv1alpha1.Heartbeat,
@@ -114,7 +169,16 @@ func (u *StatusUpdater) UpdateHealthCheckErrorStatus(
 	)
 }
 
-// UpdateInvalidRangeStatus updates the status when the status code range is invalid
+// UpdateInvalidRangeStatus updates the status when the status code range is invalid.
+// This method logs the issue and sets the status to indicate an invalid configuration.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - heartbeat: The Heartbeat resource to update
+//   - statusCode: HTTP status code if available (0 if not applicable)
+//
+// Returns:
+//   - error: Non-nil if the status update failed, nil otherwise
 func (u *StatusUpdater) UpdateInvalidRangeStatus(
 	ctx context.Context,
 	heartbeat *monitoringv1alpha1.Heartbeat,
@@ -131,7 +195,20 @@ func (u *StatusUpdater) UpdateInvalidRangeStatus(
 	)
 }
 
-// UpdateHealthStatus updates the status based on the health check result
+// UpdateHealthStatus updates the status based on the health check result.
+// This method sets the status to reflect whether the endpoint is healthy or unhealthy,
+// including the report status for monitoring systems.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - heartbeat: The Heartbeat resource to update
+//   - healthy: Whether the endpoint is considered healthy
+//   - statusCode: HTTP status code returned by the endpoint
+//   - err: Error from health checking (nil if successful)
+//   - reportSuccess: Whether the report to monitoring systems was successful
+//
+// Returns:
+//   - error: Non-nil if the status update failed, nil otherwise
 func (u *StatusUpdater) UpdateHealthStatus(
 	ctx context.Context,
 	heartbeat *monitoringv1alpha1.Heartbeat,

--- a/internal/controller/status_updater_test.go
+++ b/internal/controller/status_updater_test.go
@@ -181,12 +181,14 @@ func TestUpdateHealthStatus(t *testing.T) {
 				tt.healthy,
 				tt.statusCode,
 				tt.err,
+				true,
 			)
 
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			g.Expect(heartbeat.Status.LastStatus).To(gomega.Equal(tt.statusCode))
 			g.Expect(heartbeat.Status.Healthy).To(gomega.Equal(tt.healthy))
 			g.Expect(heartbeat.Status.Message).To(gomega.Equal(tt.expectedMsg))
+			g.Expect(heartbeat.Status.ReportStatus).To(gomega.Equal("Success"))
 		})
 	}
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -41,20 +41,27 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
+// Global variables used across the test suite for shared resources.
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
+	cfg       *rest.Config         // Kubernetes REST config for the test environment
+	k8sClient client.Client        // Kubernetes client for interacting with the test cluster
+	testEnv   *envtest.Environment // Test environment providing a local Kubernetes cluster
+	ctx       context.Context      // Context for test operations
+	cancel    context.CancelFunc   // Cancel function for the test context
 )
 
+// TestAPIs is the main entry point for the test suite.
+// It registers the Ginkgo fail handler and runs all test specs.
+// This function is called by the Go testing framework.
 func TestAPIs(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	ginkgo.RunSpecs(t, "Controller Suite")
 }
 
+// BeforeSuite sets up the test environment before any tests run.
+// It initialises a local Kubernetes cluster, creates the necessary clients,
+// and starts the controller manager for integration testing.
 var _ = ginkgo.BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
 
@@ -106,6 +113,8 @@ var _ = ginkgo.BeforeSuite(func() {
 	}()
 })
 
+// AfterSuite cleans up the test environment after all tests have completed.
+// It cancels the test context and stops the local Kubernetes cluster.
 var _ = ginkgo.AfterSuite(func() {
 	ginkgo.By("tearing down the test environment")
 	cancel()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package e2e contains end-to-end tests for the Heartbeats operator.
+// These tests verify the complete functionality of the operator in a real Kubernetes environment,
+// including controller manager operation, metrics endpoint availability, and Heartbeat resource
+// reconciliation with various endpoint configurations.
 package e2e
 
 import (
@@ -46,10 +50,13 @@ const metricsServiceName = "heartbeats-operator-controller-manager-metrics-servi
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
 const metricsRoleBindingName = "heartbeats-operator-metrics-binding"
 
+// ManagerTestSuite contains all the e2e tests related to the controller manager functionality.
+// This includes tests for basic manager operation, metrics endpoint availability, and controller health.
 var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 	var controllerPodName string
 
-	// Before running the tests, create a kind cluster and set up the environment
+	// BeforeAll sets up the test environment before any manager tests run.
+	// It configures the namespace with restricted security policy for testing.
 	ginkgo.BeforeAll(func() {
 		ginkgo.By("labeling the namespace to enforce the restricted security policy")
 		cmd := exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
@@ -58,610 +65,230 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to label namespace with restricted policy")
 	})
 
-	// After each test, check for failures and collect logs, events,
-	// and pod descriptions for debugging.
+	// AfterEach collects diagnostic information when tests fail.
+	// It fetches logs, events, and pod descriptions to help with debugging.
 	ginkgo.AfterEach(func() {
 		specReport := ginkgo.CurrentSpecReport()
 		if specReport.Failed() {
-			ginkgo.By("Fetching controller manager pod logs")
-			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-			controllerLogs, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Controller logs:\n %s", controllerLogs)
-			} else {
-				_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Controller logs: %s", err)
-			}
-
-			ginkgo.By("Fetching Kubernetes events")
-			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
-			eventsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
-			} else {
-				_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Kubernetes events: %s", err)
-			}
-
-			ginkgo.By("Fetching curl-metrics logs")
-			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
-			metricsOutput, err := utils.Run(cmd)
-			if err == nil {
-				_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
-			} else {
-				_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
-			}
-
-			ginkgo.By("Fetching controller manager pod description")
-			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
-			podDescription, err := utils.Run(cmd)
-			if err == nil {
-				fmt.Println("Pod description:\n", podDescription)
-			} else {
-				fmt.Println("Failed to describe controller pod")
-			}
+			collectManagerDiagnosticInfo(controllerPodName)
 		}
 	})
 
 	ginkgo.Context("Manager", func() {
+		// TestManagerBasicOperation verifies that the controller manager pod is running correctly.
+		// It checks that the pod exists, is in Running state, and has the expected name format.
 		ginkgo.It("should run successfully", func() {
 			ginkgo.By("validating that the controller-manager pod is running as expected")
 			verifyControllerUp := func(g gomega.Gomega) {
-				// Get the name of the controller-manager pod
-				cmd := exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
-				)
-
-				podOutput, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to retrieve controller-manager pod information")
-				podNames := utils.GetNonEmptyLines(podOutput)
-				g.Expect(podNames).To(gomega.HaveLen(1), "expected 1 controller pod running")
-				controllerPodName = podNames[0]
-				g.Expect(controllerPodName).To(gomega.ContainSubstring("controller-manager"))
-
-				// Validate the pod's status
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
-				)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("Running"), "Incorrect controller-manager pod status")
+				controllerPodName = getControllerPodName(g)
+				verifyPodStatus(g, controllerPodName)
 			}
 			gomega.Eventually(verifyControllerUp).Should(gomega.Succeed())
 		})
 
+		// TestMetricsEndpoint verifies that the metrics endpoint is properly configured and accessible.
+		// It sets up RBAC, creates a test pod to access metrics, and validates the metrics output.
 		ginkgo.It("should ensure the metrics endpoint is serving metrics", func() {
-			ginkgo.By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=heartbeats-operator-metrics-reader",
-				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-			)
-			_, err := utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create ClusterRoleBinding")
-
-			ginkgo.By("validating that the metrics service is available")
-			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Metrics service should exist")
-
-			ginkgo.By("getting the service account token")
-			token, err := serviceAccountToken()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(token).NotTo(gomega.BeEmpty())
-
-			ginkgo.By("waiting for the metrics endpoint to be ready")
-			verifyMetricsEndpointReady := func(g gomega.Gomega) {
-				cmd := exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.ContainSubstring("8443"), "Metrics endpoint is not ready")
-			}
-			gomega.Eventually(verifyMetricsEndpointReady).Should(gomega.Succeed())
-
-			ginkgo.By("verifying that the controller manager is serving the metrics server")
-			verifyMetricsServerStarted := func(g gomega.Gomega) {
-				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.ContainSubstring("controller-runtime.metrics\tServing metrics server"),
-					"Metrics server not yet started")
-			}
-			gomega.Eventually(verifyMetricsServerStarted).Should(gomega.Succeed())
-
-			ginkgo.By("creating the curl-metrics pod to access the metrics endpoint")
-			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
-				"--namespace", namespace,
-				"--image=curlimages/curl:latest",
-				"--overrides",
-				fmt.Sprintf(`{
-					"spec": {
-						"containers": [{
-							"name": "curl",
-							"image": "curlimages/curl:latest",
-							"command": ["/bin/sh", "-c"],
-							"args": ["curl -v -k -H \"Authorization: Bearer $TOKEN\" https://%s.%s.svc.cluster.local:8443/metrics"],
-							"env": [{
-								"name": "TOKEN",
-								"value": "%s"
-							}],
-							"securityContext": {
-								"allowPrivilegeEscalation": false,
-								"capabilities": {
-									"drop": ["ALL"]
-								},
-								"runAsNonRoot": true,
-								"runAsUser": 1000,
-								"seccompProfile": {
-									"type": "RuntimeDefault"
-								}
-							}
-						}],
-						"serviceAccount": "%s"
-					}
-				}`, metricsServiceName, namespace, token, serviceAccountName))
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create curl-metrics pod")
-
-			ginkgo.By("waiting for the curl-metrics pod to complete")
-			verifyCurlUp := func(g gomega.Gomega) {
-				cmd := exec.Command("kubectl", "get", "pods", "curl-metrics",
-					"-o", "jsonpath={.status.phase}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("Succeeded"), "curl pod in wrong status")
-			}
-			gomega.Eventually(verifyCurlUp, 5*time.Minute, 5*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("getting the metrics by checking curl-metrics logs")
-			metricsOutput := getMetricsOutput()
-			gomega.Expect(metricsOutput).To(gomega.ContainSubstring(
-				"controller_runtime_reconcile_total",
-			))
-		})
-
-		// +kubebuilder:scaffold:e2e-webhooks-checks
-
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput := getMetricsOutput()
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
-	})
-
-	ginkgo.Context("Heartbeat", ginkgo.Ordered, func() {
-		const (
-			heartbeatName            = "test-heartbeat"
-			healthySecretName        = "heartbeat-endpoints-healthy"
-			unhealthySecretName      = "heartbeat-endpoints-unhealthy"
-			invalidSecretName        = "heartbeat-endpoints-invalid"
-			missingKeysSecretName    = "heartbeat-endpoints-missing-keys"
-			multipleRangesSecretName = "heartbeat-endpoints-multiple-ranges"
-			timeoutSecretName        = "heartbeat-endpoints-timeout"
-		)
-
-		ginkgo.BeforeAll(func() {
-			ginkgo.By("creating a secret with endpoints")
-			cmd := exec.Command("kubectl", "create", "secret", "generic", healthySecretName,
-				"--from-literal=targetEndpoint=https://httpbin.org/status/200",
-				"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
-				"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
-				"-n", namespace)
-			_, err := utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
-		})
-
-		ginkgo.AfterEach(func() {
-			ginkgo.By("deleting the Heartbeat resources")
-			cmd := exec.Command("kubectl", "delete", "heartbeat", heartbeatName, "-n", namespace)
-			_, _ = utils.Run(cmd)
-			cmd = exec.Command("kubectl", "delete", "heartbeat", heartbeatName+"-unhealthy", "-n", namespace)
-			_, _ = utils.Run(cmd)
-		})
-
-		ginkgo.It("should create and reconcile a healthy Heartbeat", func() {
-			var cmd *exec.Cmd
-			var err error
-			var output string
-
-			ginkgo.By("creating a Heartbeat resource")
-			heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
-kind: Heartbeat
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  endpointsSecret:
-    name: %s
-    targetEndpointKey: targetEndpoint
-    healthyEndpointKey: healthyEndpoint
-    unhealthyEndpointKey: unhealthyEndpoint
-  interval: 30s
-  expectedStatusCodeRanges:
-    - min: 200
-      max: 299`, heartbeatName, namespace, healthySecretName)
-
-			cmd = exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(heartbeatYAML)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
-
-			ginkgo.By("verifying the Heartbeat status becomes Healthy")
-			verifyHeartbeatHealthy := func(g gomega.Gomega) {
-				cmd := exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-					"-o", "jsonpath={.status.healthy}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("true"), "Heartbeat status is not Healthy")
-
-				// Check reportStatus is 'Success'
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-					"-o", "jsonpath={.status.reportStatus}",
-					"-n", namespace)
-				reportStatus, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(reportStatus).To(gomega.Equal("Success"), "reportStatus should be 'Success'")
-			}
-			gomega.Eventually(verifyHeartbeatHealthy, 30*time.Second, 5*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("verifying the Heartbeat message contains the correct status code")
-			cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-				"-o", "jsonpath={.status.message}",
-				"-n", namespace)
-			output, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(output).To(gomega.Equal(controller.ErrEndpointHealthy))
-		})
-
-		ginkgo.It("should handle unhealthy endpoints correctly", func() {
-			var output string
-			var err error
-			var cmd *exec.Cmd
-			ginkgo.By("creating a secret with unhealthy endpoints")
-			cmd = exec.Command("kubectl", "create", "secret", "generic", unhealthySecretName,
-				"--from-literal=targetEndpoint=https://httpbin.org/status/500",
-				"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
-				"--from-literal=unhealthyEndpoint=https://httpbin.org/status/500",
-				"-n", namespace)
-			output, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
-
-			ginkgo.By("creating a Heartbeat resource")
-			heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
-kind: Heartbeat
-metadata:
-  name: %s-unhealthy
-  namespace: %s
-spec:
-  endpointsSecret:
-    name: %s
-    targetEndpointKey: targetEndpoint
-    healthyEndpointKey: healthyEndpoint
-    unhealthyEndpointKey: unhealthyEndpoint
-  interval: 30s
-  expectedStatusCodeRanges:
-    - min: 200
-      max: 299`, heartbeatName, namespace, unhealthySecretName)
-
-			cmd = exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(heartbeatYAML)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
-
-			ginkgo.By("verifying the Heartbeat status becomes Unhealthy")
-			verifyHeartbeatUnhealthy := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName+"-unhealthy",
-					"-o", "jsonpath={.status.healthy}",
-					"-n", namespace)
-				output, err = utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("false"), "Heartbeat status is not Unhealthy")
-
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName+"-unhealthy",
-					"-o", "jsonpath={.status.reportStatus}",
-					"-n", namespace)
-				reportStatus, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(reportStatus).To(gomega.Equal("Failure"), "reportStatus should be 'Failure'")
-			}
-			gomega.Eventually(verifyHeartbeatUnhealthy, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
-		})
-
-		ginkgo.It("should handle invalid endpoint URLs", func() {
-			var err error
-			var cmd *exec.Cmd
-
-			ginkgo.By("creating a secret with an invalid endpoint URL")
-			secretYAML := fmt.Sprintf(`apiVersion: v1
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-type: Opaque
-data:
-  targetEndpoint: %s
-  healthyEndpoint: %s
-  unhealthyEndpoint: %s`, invalidSecretName, namespace,
-				base64.StdEncoding.EncodeToString([]byte("")),
-				base64.StdEncoding.EncodeToString([]byte("https://httpbin.org/status/200")),
-				base64.StdEncoding.EncodeToString([]byte("https://httpbin.org/status/200")))
-
-			cmd = exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(secretYAML)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
-
-			ginkgo.By("verifying the secret was created")
-			cmd = exec.Command("kubectl", "get", "secret", invalidSecretName, "-n", namespace)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Secret not found")
-		})
-
-		ginkgo.It("should handle missing secret keys", func() {
-			ginkgo.By("creating a secret with missing keys")
-			var cmd *exec.Cmd
-			var err error
-			var output string
-
-			// First create the secret
-			cmd = exec.Command("kubectl", "create", "secret", "generic", missingKeysSecretName,
-				"--from-literal=targetEndpoint=https://httpbin.org/status/200",
-				"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
-				"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
-				"-n", namespace)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
-
-			// Then get the secret in YAML format
-			cmd = exec.Command("kubectl", "get", "secret", missingKeysSecretName,
-				"-n", namespace, "-o", "yaml")
-			output, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Parse the YAML and modify it to have empty data
-			var secretYAML map[string]interface{}
-			err = yaml.Unmarshal([]byte(output), &secretYAML)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			secretYAML["data"] = map[string]interface{}{}
-
-			// Convert back to YAML
-			modifiedOutput, err := yaml.Marshal(secretYAML)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Now replace the secret with empty data
-			cmd = exec.Command("kubectl", "replace", "-f", "-")
-			cmd.Stdin = strings.NewReader(string(modifiedOutput))
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to update secret")
-
-			ginkgo.By("creating a Heartbeat resource")
-			heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
-kind: Heartbeat
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  endpointsSecret:
-    name: %s
-    targetEndpointKey: targetEndpoint
-    healthyEndpointKey: healthyEndpoint
-    unhealthyEndpointKey: unhealthyEndpoint
-  interval: 5s
-  expectedStatusCodeRanges:
-    - min: 200
-      max: 299`, heartbeatName, namespace, missingKeysSecretName)
-			cmd = exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(heartbeatYAML)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat resource")
-
-			ginkgo.By("verifying the Heartbeat status becomes Unhealthy due to missing keys")
-			verifyHeartbeatUnhealthy := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-					"-o", "jsonpath={.status.healthy}",
-					"-n", namespace)
-				output, err = utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("false"), "Heartbeat status is not Unhealthy")
-			}
-			gomega.Eventually(verifyHeartbeatUnhealthy, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("verifying the Heartbeat message indicates missing keys")
-			cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-				"-o", "jsonpath={.status.message}",
-				"-n", namespace)
-			output, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(output).To(gomega.ContainSubstring("missing required key"))
-		})
-
-		ginkgo.It("should handle invalid status code ranges", func() {
-			ginkgo.By("creating a Heartbeat with invalid status code ranges")
-			heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
-kind: Heartbeat
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  endpointsSecret:
-    name: %s
-    targetEndpointKey: targetEndpoint
-    healthyEndpointKey: healthyEndpoint
-    unhealthyEndpointKey: unhealthyEndpoint
-  interval: 5s
-  expectedStatusCodeRanges:
-    - min: 300
-      max: 200`, heartbeatName, namespace, healthySecretName)
-
-			cmd := exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(heartbeatYAML)
-			_, err := utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
-
-			ginkgo.By("waiting for the Heartbeat resource to be ready")
-			verifyHeartbeatExists := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName, "-n", namespace)
-				_, err = utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-			}
-			gomega.Eventually(verifyHeartbeatExists, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("verifying the Heartbeat status becomes Unhealthy due to invalid ranges")
-			verifyHeartbeatUnhealthy := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-					"-o", "jsonpath={.status.healthy}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("false"), "Heartbeat status is not Unhealthy")
-			}
-			gomega.Eventually(verifyHeartbeatUnhealthy, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("verifying the Heartbeat message indicates invalid ranges")
-			cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-				"-o", "jsonpath={.status.message}",
-				"-n", namespace)
-			output, err := utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(output).To(gomega.Equal(controller.ErrInvalidStatusCodeRange))
-		})
-
-		ginkgo.It("should handle multiple status code ranges", func() {
-			ginkgo.By("creating a secret with multiple status code ranges")
-			cmd := exec.Command("kubectl", "create", "secret", "generic", multipleRangesSecretName,
-				"--from-literal=targetEndpoint=https://httpbin.org/status/200",
-				"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
-				"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
-				"-n", namespace)
-			_, err := utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
-
-			ginkgo.By("creating a Heartbeat resource")
-			heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
-kind: Heartbeat
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  endpointsSecret:
-    name: %s
-    targetEndpointKey: targetEndpoint
-    healthyEndpointKey: healthyEndpoint
-    unhealthyEndpointKey: unhealthyEndpoint
-  interval: 5s
-  expectedStatusCodeRanges:
-    - min: 200
-      max: 299
-    - min: 404
-      max: 404`, heartbeatName, namespace, multipleRangesSecretName)
-
-			cmd = exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(heartbeatYAML)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
-
-			ginkgo.By("waiting for the Heartbeat resource to be ready")
-			verifyHeartbeatExists := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName, "-n", namespace)
-				_, err = utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-			}
-			gomega.Eventually(verifyHeartbeatExists, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("verifying the Heartbeat status becomes Healthy for 200 status code")
-			verifyHeartbeatHealthy := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-					"-o", "jsonpath={.status.healthy}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("true"), "Heartbeat status is not Healthy")
-			}
-			gomega.Eventually(verifyHeartbeatHealthy, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("updating the secret to return 404 status code")
-			cmd = exec.Command("kubectl", "patch", "secret", multipleRangesSecretName,
-				"--type=merge", "-p", `{"data": {
-					"targetEndpoint": "aHR0cHM6Ly9odHRwYmluLm9yZy9zdGF0dXMvNDA0",
-					"healthyEndpoint": "aHR0cHM6Ly9odHRwYmluLm9yZy9zdGF0dXMvMjAw",
-					"unhealthyEndpoint": "aHR0cHM6Ly9odHRwYmluLm9yZy9zdGF0dXMvMjAw"
-				}}`, "-n", namespace)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to update secret")
-
-			ginkgo.By("verifying the Heartbeat status becomes Healthy for 404 status code")
-			verifyHeartbeatHealthy404 := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-					"-o", "jsonpath={.status.healthy}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).To(gomega.Equal("true"), "Heartbeat status is not Healthy for 404")
-			}
-			gomega.Eventually(verifyHeartbeatHealthy404, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
-		})
-
-		ginkgo.It("should handle endpoint timeout", func() {
-			ginkgo.By("creating a secret with a timeout endpoint")
-			cmd := exec.Command("kubectl", "create", "secret", "generic", timeoutSecretName,
-				"--from-literal=targetEndpoint=https://httpbin.org/delay/15",
-				"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
-				"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
-				"-n", namespace)
-			_, err := utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
-
-			ginkgo.By("creating a Heartbeat resource")
-			heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
-kind: Heartbeat
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  endpointsSecret:
-    name: %s
-    targetEndpointKey: targetEndpoint
-    healthyEndpointKey: healthyEndpoint
-    unhealthyEndpointKey: unhealthyEndpoint
-  interval: 5s
-  expectedStatusCodeRanges:
-    - min: 200
-      max: 299`, heartbeatName, namespace, timeoutSecretName)
-
-			cmd = exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(heartbeatYAML)
-			_, err = utils.Run(cmd)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
-
-			ginkgo.By("waiting for the Heartbeat resource to be ready")
-			verifyHeartbeatExists := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName, "-n", namespace)
-				_, err = utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-			}
-			gomega.Eventually(verifyHeartbeatExists, 30*time.Second, 5*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("waiting for the Heartbeat status to be populated")
-			verifyHeartbeatStatusPopulated := func(g gomega.Gomega) {
-				cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
-					"-o", "jsonpath={.status.message}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(output).NotTo(gomega.BeEmpty(), "Heartbeat status message should be populated")
-			}
-			gomega.Eventually(verifyHeartbeatStatusPopulated, 60*time.Second, 5*time.Second).Should(gomega.Succeed())
+			setupMetricsAccess()
+			verifyMetricsAvailability(controllerPodName)
+			createMetricsTestPod()
+			verifyMetricsOutput()
 		})
 	})
 })
+
+// collectManagerDiagnosticInfo gathers logs, events, and pod descriptions for debugging failed manager tests.
+// This function is called when a test fails to provide diagnostic information.
+//
+// Parameters:
+//   - controllerPodName: The name of the controller pod to collect logs from
+func collectManagerDiagnosticInfo(controllerPodName string) {
+	ginkgo.By("Fetching controller manager pod logs")
+	cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+	controllerLogs, err := utils.Run(cmd)
+	if err == nil {
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Controller logs:\n %s", controllerLogs)
+	} else {
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Controller logs: %s", err)
+	}
+
+	ginkgo.By("Fetching Kubernetes events")
+	cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+	eventsOutput, err := utils.Run(cmd)
+	if err == nil {
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
+	} else {
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Kubernetes events: %s", err)
+	}
+
+	ginkgo.By("Fetching curl-metrics logs")
+	cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
+	metricsOutput, err := utils.Run(cmd)
+	if err == nil {
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
+	} else {
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
+	}
+
+	ginkgo.By("Fetching controller manager pod description")
+	cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
+	podDescription, err := utils.Run(cmd)
+	if err == nil {
+		fmt.Println("Pod description:\n", podDescription)
+	} else {
+		fmt.Println("Failed to describe controller pod")
+	}
+}
+
+// getControllerPodName retrieves the name of the controller manager pod.
+// It filters for pods with the controller-manager label and returns the first active pod.
+//
+// Parameters:
+//   - g: The gomega assertion interface for test assertions
+//
+// Returns:
+//   - string: The name of the controller pod
+func getControllerPodName(g gomega.Gomega) string {
+	cmd := exec.Command("kubectl", "get",
+		"pods", "-l", "control-plane=controller-manager",
+		"-o", "go-template={{ range .items }}"+
+			"{{ if not .metadata.deletionTimestamp }}"+
+			"{{ .metadata.name }}"+
+			"{{ \"\\n\" }}{{ end }}{{ end }}",
+		"-n", namespace,
+	)
+
+	podOutput, err := utils.Run(cmd)
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to retrieve controller-manager pod information")
+	podNames := utils.GetNonEmptyLines(podOutput)
+	g.Expect(podNames).To(gomega.HaveLen(1), "expected 1 controller pod running")
+	controllerPodName := podNames[0]
+	g.Expect(controllerPodName).To(gomega.ContainSubstring("controller-manager"))
+	return controllerPodName
+}
+
+// verifyPodStatus checks that the specified pod is in Running state.
+// It validates the pod's phase to ensure it's healthy and operational.
+//
+// Parameters:
+//   - g: The gomega assertion interface for test assertions
+//   - podName: The name of the pod to verify
+func verifyPodStatus(g gomega.Gomega, podName string) {
+	cmd := exec.Command("kubectl", "get",
+		"pods", podName, "-o", "jsonpath={.status.phase}",
+		"-n", namespace,
+	)
+	output, err := utils.Run(cmd)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(output).To(gomega.Equal("Running"), "Incorrect controller-manager pod status")
+}
+
+// setupMetricsAccess creates the necessary RBAC resources to access the metrics endpoint.
+// It creates a ClusterRoleBinding that allows the service account to read metrics.
+func setupMetricsAccess() {
+	ginkgo.By("creating a ClusterRoleBinding for the service account to allow access to metrics")
+	cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
+		"--clusterrole=heartbeats-operator-metrics-reader",
+		fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
+	)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create ClusterRoleBinding")
+}
+
+// verifyMetricsAvailability checks that the metrics service exists and is properly configured.
+// It validates that the metrics service is available and the endpoint is ready.
+//
+// Parameters:
+//   - controllerPodName: The name of the controller pod to check logs from
+func verifyMetricsAvailability(controllerPodName string) {
+	ginkgo.By("validating that the metrics service is available")
+	cmd := exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Metrics service should exist")
+
+	ginkgo.By("waiting for the metrics endpoint to be ready")
+	verifyMetricsEndpointReady := func(g gomega.Gomega) {
+		cmd := exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(output).To(gomega.ContainSubstring("8443"), "Metrics endpoint is not ready")
+	}
+	gomega.Eventually(verifyMetricsEndpointReady).Should(gomega.Succeed())
+
+	ginkgo.By("verifying that the controller manager is serving the metrics server")
+	verifyMetricsServerStarted := func(g gomega.Gomega) {
+		cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(output).To(gomega.ContainSubstring("controller-runtime.metrics\tServing metrics server"),
+			"Metrics server not yet started")
+	}
+	gomega.Eventually(verifyMetricsServerStarted).Should(gomega.Succeed())
+}
+
+// createMetricsTestPod creates a temporary pod to test access to the metrics endpoint.
+// It uses a curl image to make requests to the metrics service and verify connectivity.
+func createMetricsTestPod() {
+	ginkgo.By("getting the service account token")
+	token, err := serviceAccountToken()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(token).NotTo(gomega.BeEmpty())
+
+	ginkgo.By("creating the curl-metrics pod to access the metrics endpoint")
+	cmd := exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
+		"--namespace", namespace,
+		"--image=curlimages/curl:latest",
+		"--overrides",
+		fmt.Sprintf(`{
+			"spec": {
+				"containers": [{
+					"name": "curl",
+					"image": "curlimages/curl:latest",
+					"command": ["/bin/sh", "-c"],
+					"args": ["curl -v -k -H \"Authorization: Bearer $TOKEN\" https://%s.%s.svc.cluster.local:8443/metrics"],
+					"env": [{
+						"name": "TOKEN",
+						"value": "%s"
+					}],
+					"securityContext": {
+						"allowPrivilegeEscalation": false,
+						"capabilities": {
+							"drop": ["ALL"]
+						},
+						"runAsNonRoot": true,
+						"runAsUser": 1000,
+						"seccompProfile": {
+							"type": "RuntimeDefault"
+						}
+					}
+				}],
+				"serviceAccount": "%s"
+			}
+		}`, metricsServiceName, namespace, token, serviceAccountName))
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create curl-metrics pod")
+
+	ginkgo.By("waiting for the curl-metrics pod to complete")
+	verifyCurlUp := func(g gomega.Gomega) {
+		cmd = exec.Command("kubectl", "get", "pods", "curl-metrics",
+			"-o", "jsonpath={.status.phase}",
+			"-n", namespace)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(output).To(gomega.Equal("Succeeded"), "curl pod in wrong status")
+	}
+	gomega.Eventually(verifyCurlUp, 5*time.Minute, 5*time.Second).Should(gomega.Succeed())
+}
+
+// verifyMetricsOutput retrieves and validates the metrics output from the test pod.
+// It checks that the metrics contain expected controller runtime metrics.
+func verifyMetricsOutput() {
+	ginkgo.By("getting the metrics by checking curl-metrics logs")
+	metricsOutput := getMetricsOutput()
+	gomega.Expect(metricsOutput).To(gomega.ContainSubstring(
+		"controller_runtime_reconcile_total",
+	))
+}
 
 // serviceAccountToken returns a token for the specified service account in the given namespace.
 // It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
@@ -726,4 +353,543 @@ type tokenRequest struct {
 	Status struct {
 		Token string `json:"token"`
 	} `json:"status"`
+}
+
+// HeartbeatTestSuite contains all the e2e tests related to Heartbeat resource functionality.
+// This includes tests for health checking, status updates, and various endpoint configurations.
+var _ = ginkgo.Describe("Heartbeat", ginkgo.Ordered, func() {
+	// Test constants for Heartbeat resources
+	const (
+		heartbeatName            = "test-heartbeat"
+		healthySecretName        = "heartbeat-endpoints-healthy"
+		unhealthySecretName      = "heartbeat-endpoints-unhealthy"
+		invalidSecretName        = "heartbeat-endpoints-invalid"
+		missingKeysSecretName    = "heartbeat-endpoints-missing-keys"
+		multipleRangesSecretName = "heartbeat-endpoints-multiple-ranges"
+		timeoutSecretName        = "heartbeat-endpoints-timeout"
+	)
+
+	// BeforeAll sets up the test environment for Heartbeat tests.
+	// It creates the initial healthy endpoints secret used by multiple tests.
+	ginkgo.BeforeAll(func() {
+		createInitialHealthySecret(healthySecretName)
+	})
+
+	// AfterEach cleans up Heartbeat resources after each test.
+	// It ensures that test resources are properly removed to avoid interference.
+	ginkgo.AfterEach(func() {
+		cleanupHeartbeatResources(heartbeatName)
+	})
+
+	ginkgo.Context("Health Check", func() {
+		// TestHealthyEndpoints verifies that Heartbeat resources with healthy endpoints
+		// are correctly marked as healthy and have successful report status.
+		ginkgo.It("should create and reconcile a healthy Heartbeat", func() {
+			createHealthyHeartbeat(heartbeatName, healthySecretName)
+			verifyHeartbeatHealth(heartbeatName, true, "Success")
+			verifyHeartbeatMessage(heartbeatName, controller.ErrEndpointHealthy)
+		})
+
+		// TestUnhealthyEndpoints verifies that Heartbeat resources with unhealthy endpoints
+		// are correctly marked as unhealthy and have successful report status.
+		ginkgo.It("should handle unhealthy endpoints correctly", func() {
+			createUnhealthyEndpointsSecret(unhealthySecretName)
+			createUnhealthyHeartbeat(heartbeatName, unhealthySecretName)
+			verifyHeartbeatHealth(heartbeatName+"-unhealthy", false, "Failure")
+		})
+
+		// TestInvalidEndpointURLs verifies that Heartbeat resources with invalid endpoint URLs
+		// are handled gracefully and marked as unhealthy.
+		ginkgo.It("should handle invalid endpoint URLs", func() {
+			createInvalidEndpointSecret(invalidSecretName)
+			verifySecretExists(invalidSecretName)
+		})
+
+		// TestMissingKeys verifies that Heartbeat resources with missing required keys
+		// are handled gracefully and marked as unhealthy.
+		ginkgo.It("should handle missing secret keys", func() {
+			createMissingKeysSecret(missingKeysSecretName)
+			createMissingKeysHeartbeat(heartbeatName, missingKeysSecretName)
+			verifyHeartbeatHealth(heartbeatName, false, "")
+			verifyHeartbeatMessageContains(heartbeatName, "missing required key")
+		})
+
+		// TestInvalidStatusCodes verifies that Heartbeat resources with invalid status code ranges
+		// are handled gracefully and marked as unhealthy.
+		ginkgo.It("should handle invalid status code ranges", func() {
+			createInvalidStatusCodeHeartbeat(heartbeatName, healthySecretName)
+			verifyHeartbeatExists(heartbeatName)
+			verifyHeartbeatHealth(heartbeatName, false, "")
+			verifyHeartbeatMessage(heartbeatName, controller.ErrInvalidStatusCodeRange)
+		})
+
+		// TestMultipleRanges verifies that Heartbeat resources with multiple status code ranges
+		// are processed correctly and marked appropriately.
+		ginkgo.It("should handle multiple status code ranges", func() {
+			createMultipleRangesSecret(multipleRangesSecretName)
+			createMultipleRangesHeartbeat(heartbeatName, multipleRangesSecretName)
+			verifyHeartbeatExists(heartbeatName)
+			verifyHeartbeatHealth(heartbeatName, true, "")
+			updateSecretToReturn404(multipleRangesSecretName)
+			verifyHeartbeatHealth(heartbeatName, true, "")
+		})
+
+		// TestTimeout verifies that Heartbeat resources with timeout configurations
+		// are handled correctly and marked appropriately.
+		ginkgo.It("should handle endpoint timeout", func() {
+			createTimeoutSecret(timeoutSecretName)
+			createTimeoutHeartbeat(heartbeatName, timeoutSecretName)
+			verifyHeartbeatExists(heartbeatName)
+			verifyHeartbeatStatusPopulated(heartbeatName)
+		})
+	})
+})
+
+// createInitialHealthySecret creates the initial healthy endpoints secret used by multiple tests.
+// This secret is created once in BeforeAll to avoid duplication across tests.
+//
+// Parameters:
+//   - secretName: The name of the secret to create
+func createInitialHealthySecret(secretName string) {
+	ginkgo.By("creating a secret with endpoints")
+	cmd := exec.Command("kubectl", "create", "secret", "generic", secretName,
+		"--from-literal=targetEndpoint=https://httpbin.org/status/200",
+		"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
+		"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
+		"-n", namespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
+}
+
+// cleanupHeartbeatResources removes Heartbeat resources after each test.
+// This ensures that tests don't interfere with each other.
+//
+// Parameters:
+//   - heartbeatName: The base name of the Heartbeat resource to clean up
+func cleanupHeartbeatResources(heartbeatName string) {
+	ginkgo.By("deleting the Heartbeat resources")
+	cmd := exec.Command("kubectl", "delete", "heartbeat", heartbeatName, "-n", namespace)
+	_, _ = utils.Run(cmd)
+	cmd = exec.Command("kubectl", "delete", "heartbeat", heartbeatName+"-unhealthy", "-n", namespace)
+	_, _ = utils.Run(cmd)
+}
+
+// createHealthyHeartbeat creates a Heartbeat resource that references the healthy endpoints secret.
+// It applies the Heartbeat CRD and waits for it to be created.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to create
+//   - secretName: The name of the secret containing endpoint configurations
+func createHealthyHeartbeat(heartbeatName, secretName string) {
+	ginkgo.By("creating a Heartbeat resource")
+	heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  endpointsSecret:
+    name: %s
+    targetEndpointKey: targetEndpoint
+    healthyEndpointKey: healthyEndpoint
+    unhealthyEndpointKey: unhealthyEndpoint
+  interval: 30s
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299`, heartbeatName, namespace, secretName)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(heartbeatYAML)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
+}
+
+// createUnhealthyEndpointsSecret creates a secret with unhealthy endpoint configurations.
+// The endpoints are configured to return HTTP 500, which should mark the heartbeat as unhealthy.
+//
+// Parameters:
+//   - secretName: The name of the secret to create
+func createUnhealthyEndpointsSecret(secretName string) {
+	ginkgo.By("creating a secret with unhealthy endpoints")
+	cmd := exec.Command("kubectl", "create", "secret", "generic", secretName,
+		"--from-literal=targetEndpoint=https://httpbin.org/status/500",
+		"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
+		"--from-literal=unhealthyEndpoint=https://httpbin.org/status/500",
+		"-n", namespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
+}
+
+// createUnhealthyHeartbeat creates a Heartbeat resource that references the unhealthy endpoints secret.
+// It applies the Heartbeat CRD and waits for it to be created.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to create
+//   - secretName: The name of the secret containing endpoint configurations
+func createUnhealthyHeartbeat(heartbeatName, secretName string) {
+	ginkgo.By("creating a Heartbeat resource")
+	heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: %s-unhealthy
+  namespace: %s
+spec:
+  endpointsSecret:
+    name: %s
+    targetEndpointKey: targetEndpoint
+    healthyEndpointKey: healthyEndpoint
+    unhealthyEndpointKey: unhealthyEndpoint
+  interval: 30s
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299`, heartbeatName, namespace, secretName)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(heartbeatYAML)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
+}
+
+// createInvalidEndpointSecret creates a secret with an invalid endpoint URL.
+// This tests the controller's handling of malformed endpoint specifications.
+//
+// Parameters:
+//   - secretName: The name of the secret to create
+func createInvalidEndpointSecret(secretName string) {
+	ginkgo.By("creating a secret with an invalid endpoint URL")
+	secretYAML := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+type: Opaque
+data:
+  targetEndpoint: %s
+  healthyEndpoint: %s
+  unhealthyEndpoint: %s`, secretName, namespace,
+		base64.StdEncoding.EncodeToString([]byte("")),
+		base64.StdEncoding.EncodeToString([]byte("https://httpbin.org/status/200")),
+		base64.StdEncoding.EncodeToString([]byte("https://httpbin.org/status/200")))
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(secretYAML)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
+}
+
+// verifySecretExists checks that the specified secret was created successfully.
+//
+// Parameters:
+//   - secretName: The name of the secret to verify
+func verifySecretExists(secretName string) {
+	ginkgo.By("verifying the secret was created")
+	cmd := exec.Command("kubectl", "get", "secret", secretName, "-n", namespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Secret not found")
+}
+
+// createMissingKeysSecret creates a secret with missing required keys.
+// This tests the controller's handling of incomplete endpoint configurations.
+//
+// Parameters:
+//   - secretName: The name of the secret to create
+func createMissingKeysSecret(secretName string) {
+	ginkgo.By("creating a secret with missing keys")
+	var cmd *exec.Cmd
+	var err error
+	var output string
+
+	// First create the secret
+	cmd = exec.Command("kubectl", "create", "secret", "generic", secretName,
+		"--from-literal=targetEndpoint=https://httpbin.org/status/200",
+		"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
+		"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
+		"-n", namespace)
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
+
+	// Then get the secret in YAML format
+	cmd = exec.Command("kubectl", "get", "secret", secretName,
+		"-n", namespace, "-o", "yaml")
+	output, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Parse the YAML and modify it to have empty data
+	var secretYAML map[string]interface{}
+	err = yaml.Unmarshal([]byte(output), &secretYAML)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	secretYAML["data"] = map[string]interface{}{}
+
+	// Convert back to YAML
+	modifiedOutput, err := yaml.Marshal(secretYAML)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Now replace the secret with empty data
+	cmd = exec.Command("kubectl", "replace", "-f", "-")
+	cmd.Stdin = strings.NewReader(string(modifiedOutput))
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to update secret")
+}
+
+// createMissingKeysHeartbeat creates a Heartbeat resource that references the missing keys secret.
+// It applies the Heartbeat CRD and waits for it to be created.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to create
+//   - secretName: The name of the secret containing endpoint configurations
+func createMissingKeysHeartbeat(heartbeatName, secretName string) {
+	ginkgo.By("creating a Heartbeat resource")
+	heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  endpointsSecret:
+    name: %s
+    targetEndpointKey: targetEndpoint
+    healthyEndpointKey: healthyEndpoint
+    unhealthyEndpointKey: unhealthyEndpoint
+  interval: 5s
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299`, heartbeatName, namespace, secretName)
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(heartbeatYAML)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat resource")
+}
+
+// createInvalidStatusCodeHeartbeat creates a Heartbeat resource with invalid status code ranges.
+// This tests the controller's handling of malformed status code specifications.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to create
+//   - secretName: The name of the secret containing endpoint configurations
+func createInvalidStatusCodeHeartbeat(heartbeatName, secretName string) {
+	ginkgo.By("creating a Heartbeat with invalid status code ranges")
+	heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  endpointsSecret:
+    name: %s
+    targetEndpointKey: targetEndpoint
+    healthyEndpointKey: healthyEndpoint
+    unhealthyEndpointKey: unhealthyEndpoint
+  interval: 5s
+  expectedStatusCodeRanges:
+    - min: 300
+      max: 200`, heartbeatName, namespace, secretName)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(heartbeatYAML)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
+}
+
+// createMultipleRangesSecret creates a secret with multiple status code range configurations.
+// This tests the controller's handling of complex status code specifications.
+//
+// Parameters:
+//   - secretName: The name of the secret to create
+func createMultipleRangesSecret(secretName string) {
+	ginkgo.By("creating a secret with multiple status code ranges")
+	cmd := exec.Command("kubectl", "create", "secret", "generic", secretName,
+		"--from-literal=targetEndpoint=https://httpbin.org/status/200",
+		"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
+		"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
+		"-n", namespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
+}
+
+// createMultipleRangesHeartbeat creates a Heartbeat resource that references the multiple ranges secret.
+// It applies the Heartbeat CRD and waits for it to be created.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to create
+//   - secretName: The name of the secret containing endpoint configurations
+func createMultipleRangesHeartbeat(heartbeatName, secretName string) {
+	ginkgo.By("creating a Heartbeat resource")
+	heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  endpointsSecret:
+    name: %s
+    targetEndpointKey: targetEndpoint
+    healthyEndpointKey: healthyEndpoint
+    unhealthyEndpointKey: unhealthyEndpoint
+  interval: 5s
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299
+    - min: 404
+      max: 404`, heartbeatName, namespace, secretName)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(heartbeatYAML)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
+}
+
+// createTimeoutSecret creates a secret with timeout configurations.
+// This tests the controller's handling of timeout settings.
+//
+// Parameters:
+//   - secretName: The name of the secret to create
+func createTimeoutSecret(secretName string) {
+	ginkgo.By("creating a secret with a timeout endpoint")
+	cmd := exec.Command("kubectl", "create", "secret", "generic", secretName,
+		"--from-literal=targetEndpoint=https://httpbin.org/delay/15",
+		"--from-literal=healthyEndpoint=https://httpbin.org/status/200",
+		"--from-literal=unhealthyEndpoint=https://httpbin.org/status/200",
+		"-n", namespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create secret")
+}
+
+// createTimeoutHeartbeat creates a Heartbeat resource that references the timeout secret.
+// It applies the Heartbeat CRD and waits for it to be created.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to create
+//   - secretName: The name of the secret containing endpoint configurations
+func createTimeoutHeartbeat(heartbeatName, secretName string) {
+	ginkgo.By("creating a Heartbeat resource")
+	heartbeatYAML := fmt.Sprintf(`apiVersion: monitoring.siutsin.com/v1alpha1
+kind: Heartbeat
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  endpointsSecret:
+    name: %s
+    targetEndpointKey: targetEndpoint
+    healthyEndpointKey: healthyEndpoint
+    unhealthyEndpointKey: unhealthyEndpoint
+  interval: 5s
+  expectedStatusCodeRanges:
+    - min: 200
+      max: 299`, heartbeatName, namespace, secretName)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(heartbeatYAML)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create Heartbeat")
+}
+
+// verifyHeartbeatExists checks that the specified Heartbeat resource exists.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to verify
+func verifyHeartbeatExists(heartbeatName string) {
+	ginkgo.By("waiting for the Heartbeat resource to be ready")
+	verifyHeartbeatExists := func(g gomega.Gomega) {
+		cmd := exec.Command("kubectl", "get", "heartbeat", heartbeatName, "-n", namespace)
+		_, err := utils.Run(cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+	gomega.Eventually(verifyHeartbeatExists, 10*time.Second, 3*time.Second).Should(gomega.Succeed())
+}
+
+// verifyHeartbeatHealth verifies that the Heartbeat resource has the expected health status and report status.
+// It polls the Heartbeat status until the expected values are reached or timeout occurs.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to verify
+//   - expectedHealthy: The expected health status (true for healthy, false for unhealthy)
+//   - expectedReportStatus: The expected report status (e.g., "Success", "Failure")
+func verifyHeartbeatHealth(heartbeatName string, expectedHealthy bool, expectedReportStatus string) {
+	ginkgo.By("verifying the Heartbeat status")
+	verifyHeartbeatStatus := func(g gomega.Gomega) {
+		cmd := exec.Command("kubectl", "get", "heartbeat", heartbeatName,
+			"-o", "jsonpath={.status.healthy}",
+			"-n", namespace)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		healthy := output == "true"
+		g.Expect(healthy).To(gomega.Equal(expectedHealthy), "Heartbeat health status mismatch")
+
+		if expectedReportStatus != "" {
+			// Check reportStatus
+			cmd = exec.Command("kubectl", "get", "heartbeat", heartbeatName,
+				"-o", "jsonpath={.status.reportStatus}",
+				"-n", namespace)
+			reportStatus, err := utils.Run(cmd)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(reportStatus).To(gomega.Equal(expectedReportStatus), "reportStatus mismatch")
+		}
+	}
+	gomega.Eventually(verifyHeartbeatStatus, 30*time.Second, 5*time.Second).Should(gomega.Succeed())
+}
+
+// verifyHeartbeatMessage verifies that the Heartbeat resource has the expected status message.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to verify
+//   - expectedMessage: The expected status message
+func verifyHeartbeatMessage(heartbeatName, expectedMessage string) {
+	ginkgo.By("verifying the Heartbeat message contains the correct status code")
+	cmd := exec.Command("kubectl", "get", "heartbeat", heartbeatName,
+		"-o", "jsonpath={.status.message}",
+		"-n", namespace)
+	output, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(output).To(gomega.Equal(expectedMessage))
+}
+
+// verifyHeartbeatMessageContains verifies that the Heartbeat resource's status message contains the expected substring.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to verify
+//   - expectedSubstring: The expected substring in the status message
+func verifyHeartbeatMessageContains(heartbeatName, expectedSubstring string) {
+	ginkgo.By("verifying the Heartbeat message indicates missing keys")
+	cmd := exec.Command("kubectl", "get", "heartbeat", heartbeatName,
+		"-o", "jsonpath={.status.message}",
+		"-n", namespace)
+	output, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(output).To(gomega.ContainSubstring(expectedSubstring))
+}
+
+// updateSecretToReturn404 updates the secret to return a 404 status code.
+// This tests the controller's handling of different status codes within the valid range.
+//
+// Parameters:
+//   - secretName: The name of the secret to update
+func updateSecretToReturn404(secretName string) {
+	ginkgo.By("updating the secret to return 404 status code")
+	cmd := exec.Command("kubectl", "patch", "secret", secretName,
+		"--type=merge", "-p", `{"data": {
+			"targetEndpoint": "aHR0cHM6Ly9odHRwYmluLm9yZy9zdGF0dXMvNDA0",
+			"healthyEndpoint": "aHR0cHM6Ly9odHRwYmluLm9yZy9zdGF0dXMvMjAw",
+			"unhealthyEndpoint": "aHR0cHM6Ly9odHRwYmluLm9yZy9zdGF0dXMvMjAw"
+		}}`, "-n", namespace)
+	_, err := utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to update secret")
+}
+
+// verifyHeartbeatStatusPopulated verifies that the Heartbeat resource's status message is populated.
+// This is used for tests where we expect the status to be set but don't care about the specific value.
+//
+// Parameters:
+//   - heartbeatName: The name of the Heartbeat resource to verify
+func verifyHeartbeatStatusPopulated(heartbeatName string) {
+	ginkgo.By("waiting for the Heartbeat status to be populated")
+	verifyHeartbeatStatusPopulated := func(g gomega.Gomega) {
+		cmd := exec.Command("kubectl", "get", "heartbeat", heartbeatName,
+			"-o", "jsonpath={.status.message}",
+			"-n", namespace)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(output).NotTo(gomega.BeEmpty(), "Heartbeat status message should be populated")
+	}
+	gomega.Eventually(verifyHeartbeatStatusPopulated, 60*time.Second, 5*time.Second).Should(gomega.Succeed())
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package utils provides utility functions for e2e testing.
+// This package contains helper functions for executing commands, managing Kubernetes resources,
+// and handling common testing operations like installing/uninstalling operators and checking CRDs.
 package utils
 
 import (
@@ -27,20 +30,39 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2" //nolint:revive
 )
 
+// Constants for operator versions and URLs
 const (
+	// prometheusOperatorVersion specifies the version of Prometheus Operator to install
 	prometheusOperatorVersion = "v0.77.1"
-	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
+	// prometheusOperatorURL is the base URL for downloading Prometheus Operator bundle
+	prometheusOperatorURL = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
+	// certmanagerVersion specifies the version of cert-manager to install
 	certmanagerVersion = "v1.16.3"
+	// certmanagerURLTmpl is the template URL for downloading cert-manager bundle
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
+// warnError logs a warning message when an error occurs during cleanup operations.
+// This function is used for non-critical errors that shouldn't fail the test.
+//
+// Parameters:
+//   - err: The error to log as a warning
 func warnError(err error) {
 	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "warning: %v\n", err)
 }
 
-// Run executes the provided command within this context
+// Run executes the provided command within the project context.
+// It sets up the working directory, environment variables, and captures both stdout and stderr.
+// The function logs the command being executed and returns the combined output.
+//
+// Parameters:
+//   - cmd: The command to execute
+//
+// Returns:
+//   - string: The combined stdout and stderr output
+//   - error: Any error that occurred during command execution
 func Run(cmd *exec.Cmd) (string, error) {
 	dir, _ := GetProjectDir()
 	cmd.Dir = dir
@@ -60,7 +82,59 @@ func Run(cmd *exec.Cmd) (string, error) {
 	return string(output), nil
 }
 
-// InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
+// RunWithInput executes the provided command with input from stdin.
+// This is useful for commands like `kubectl apply -f -` that expect YAML input.
+//
+// Parameters:
+//   - cmd: The command to execute
+//   - input: The input string to provide via stdin
+//
+// Returns:
+//   - string: The combined stdout and stderr output
+//   - error: Any error that occurred during command execution
+func RunWithInput(cmd *exec.Cmd, input string) (string, error) {
+	dir, _ := GetProjectDir()
+	cmd.Dir = dir
+
+	if err := os.Chdir(cmd.Dir); err != nil {
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "chdir dir: %s\n", err)
+	}
+
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	command := strings.Join(cmd.Args, " ")
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "running: %s\n", command)
+
+	// Set up stdin pipe
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return "", fmt.Errorf("failed to create stdin pipe: %v", err)
+	}
+
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("failed to start command: %v", err)
+	}
+
+	// Write input to stdin
+	if _, err := stdin.Write([]byte(input)); err != nil {
+		return "", fmt.Errorf("failed to write to stdin: %v", err)
+	}
+	stdin.Close()
+
+	// Wait for command to complete
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
+	}
+
+	return string(output), nil
+}
+
+// InstallPrometheusOperator installs the Prometheus Operator to be used for exporting metrics.
+// It downloads and applies the operator bundle from the official GitHub releases.
+//
+// Returns:
+//   - error: Any error that occurred during installation
 func InstallPrometheusOperator() error {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
 	cmd := exec.Command("kubectl", "create", "-f", url)
@@ -68,7 +142,9 @@ func InstallPrometheusOperator() error {
 	return err
 }
 
-// UninstallPrometheusOperator uninstalls the prometheus
+// UninstallPrometheusOperator uninstalls the Prometheus Operator.
+// It removes the operator bundle that was previously installed.
+// Errors during uninstallation are logged as warnings since they're not critical.
 func UninstallPrometheusOperator() {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
 	cmd := exec.Command("kubectl", "delete", "-f", url)
@@ -79,8 +155,12 @@ func UninstallPrometheusOperator() {
 
 // IsPrometheusCRDsInstalled checks if any Prometheus CRDs are installed
 // by verifying the existence of key CRDs related to Prometheus.
+// This function is useful for determining if Prometheus Operator is already installed.
+//
+// Returns:
+//   - bool: True if any Prometheus CRDs are found, false otherwise
 func IsPrometheusCRDsInstalled() bool {
-	// List of common Prometheus CRDs
+	// List of common Prometheus CRDs to check for
 	prometheusCRDs := []string{
 		"prometheuses.monitoring.coreos.com",
 		"prometheusrules.monitoring.coreos.com",
@@ -104,7 +184,9 @@ func IsPrometheusCRDsInstalled() bool {
 	return false
 }
 
-// UninstallCertManager uninstalls the cert manager
+// UninstallCertManager uninstalls the cert-manager bundle.
+// It removes the cert-manager that was previously installed.
+// Errors during uninstallation are logged as warnings since they're not critical.
 func UninstallCertManager() {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
 	cmd := exec.Command("kubectl", "delete", "-f", url)
@@ -113,13 +195,20 @@ func UninstallCertManager() {
 	}
 }
 
-// InstallCertManager installs the cert manager bundle.
+// InstallCertManager installs the cert-manager bundle.
+// It downloads and applies the cert-manager bundle, then waits for the webhook to be ready.
+// The webhook readiness check is important because cert-manager may be re-installed
+// after uninstalling on a cluster.
+//
+// Returns:
+//   - error: Any error that occurred during installation
 func InstallCertManager() error {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
 	cmd := exec.Command("kubectl", "apply", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		return err
 	}
+
 	// Wait for cert-manager-webhook to be ready, which can take time if cert-manager
 	// was re-installed after uninstalling on a cluster.
 	cmd = exec.Command("kubectl", "wait", "deployment.apps/cert-manager-webhook",
@@ -134,8 +223,12 @@ func InstallCertManager() error {
 
 // IsCertManagerCRDsInstalled checks if any Cert Manager CRDs are installed
 // by verifying the existence of key CRDs related to Cert Manager.
+// This function is useful for determining if cert-manager is already installed.
+//
+// Returns:
+//   - bool: True if any Cert Manager CRDs are found, false otherwise
 func IsCertManagerCRDsInstalled() bool {
-	// List of common Cert Manager CRDs
+	// List of common Cert Manager CRDs to check for
 	certManagerCRDs := []string{
 		"certificates.cert-manager.io",
 		"issuers.cert-manager.io",
@@ -165,7 +258,15 @@ func IsCertManagerCRDsInstalled() bool {
 	return false
 }
 
-// LoadImageToKindClusterWithName loads a local docker image to the kind cluster
+// LoadImageToKindClusterWithName loads a local docker image to the kind cluster.
+// This function is useful for testing with custom images that aren't available in public registries.
+// The cluster name can be overridden by setting the KIND_CLUSTER environment variable.
+//
+// Parameters:
+//   - name: The name of the docker image to load
+//
+// Returns:
+//   - error: Any error that occurred during image loading
 func LoadImageToKindClusterWithName(name string) error {
 	cluster := "kind"
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
@@ -179,6 +280,13 @@ func LoadImageToKindClusterWithName(name string) error {
 
 // GetNonEmptyLines converts given command output string into individual objects
 // according to line breakers, and ignores the empty elements in it.
+// This function is useful for parsing command output that contains multiple lines.
+//
+// Parameters:
+//   - output: The command output string to parse
+//
+// Returns:
+//   - []string: A slice of non-empty lines from the output
 func GetNonEmptyLines(output string) []string {
 	var res []string
 	elements := strings.Split(output, "\n")
@@ -191,7 +299,13 @@ func GetNonEmptyLines(output string) []string {
 	return res
 }
 
-// GetProjectDir will return the directory where the project is
+// GetProjectDir will return the directory where the project is located.
+// It handles the case where the current working directory might be in a subdirectory
+// like test/e2e and adjusts the path accordingly.
+//
+// Returns:
+//   - string: The project root directory path
+//   - error: Any error that occurred while getting the working directory
 func GetProjectDir() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -201,8 +315,17 @@ func GetProjectDir() (string, error) {
 	return wd, nil
 }
 
-// UncommentCode searches for target in the file and remove the comment prefix
+// UncommentCode searches for target in the file and removes the comment prefix
 // of the target content. The target content may span multiple lines.
+// This function is useful for programmatically enabling features in configuration files.
+//
+// Parameters:
+//   - filename: The path to the file to modify
+//   - target: The target content to uncomment
+//   - prefix: The comment prefix to remove (e.g., "// " or "# ")
+//
+// Returns:
+//   - error: Any error that occurred during file modification
 func UncommentCode(filename, target, prefix string) error {
 	// false positive
 	// nolint:gosec

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -119,7 +119,9 @@ func RunWithInput(cmd *exec.Cmd, input string) (string, error) {
 	if _, err := stdin.Write([]byte(input)); err != nil {
 		return "", fmt.Errorf("failed to write to stdin: %v", err)
 	}
-	stdin.Close()
+	if err := stdin.Close(); err != nil {
+		return "", fmt.Errorf("failed to close stdin: %v", err)
+	}
 
 	// Wait for command to complete
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary by Sourcery

Implement health check result reporting to external endpoints and refactor controller and tests for improved modularity, error handling, and configurability

New Features:
- Add support for reporting health check results to configurable healthy and unhealthy endpoints
- Introduce HTTP method configuration for target, healthy and unhealthy endpoints
- Extend Heartbeat CRD and status with a `reportStatus` field indicating report success

Enhancements:
- Refactor HeartbeatReconciler into discrete methods for fetching resources, validating secrets, extracting endpoints, and performing health checks with reporting
- Upgrade HealthChecker to return a report success flag and use retryable HTTP client for all requests
- Improve error handling, logging, and status updates across controller, health checker, and status updater
- Streamline e2e tests by extracting common setup, teardown, and diagnostic functions
- Enhance Makefile with distinct test/test-ci and e2e/test-e2e-ci targets and add markdown linting support

CI:
- Update GitHub workflows to run new CI targets (`make test-ci`, `make test-e2e-ci`)

Documentation:
- Update README with report endpoint usage, new fields, error messages, and advanced examples
- Extend CRD schema to include endpoint method fields and `reportStatus`
- Polish SECURITY.md formatting and add markdownlint configuration

Tests:
- Add extensive unit tests for HealthChecker covering success, failure, network errors, timeouts, and reporting
- Add unit tests for StatusUpdater, config defaults, and HeartbeatReconciler logic
- Refine e2e test suite with BeforeSuite/AfterSuite, helper functions, and report endpoint scenarios