### PR TITLE
chore: remove stdr

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -7,3 +7,5 @@ alwaysApply: true
 
 - Write comments and documentation in British English.
 - Markdown should be checked against markdownlint rules.
+- To test, run `make lint-markdown-fix && make lint && make test && make test-e2e LOCAL=true`
+- Auto fix and run test without asking me to confirm

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ godebug default=go1.24
 
 require (
 	github.com/go-logr/logr v1.4.3
-	github.com/go-logr/stdr v1.2.2
 	github.com/goccy/go-yaml v1.18.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
@@ -30,6 +29,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -3,6 +3,7 @@ package logger_test
 import (
 	"context"
 	"errors"
+
 	"testing"
 
 	"github.com/go-logr/logr"

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,4 +10,10 @@
   },
   minimumReleaseAge: '3 days',
   rebaseWhen: "behind-base-branch",
+  packageRules: [
+    {
+      matchPackageNames: ['github.com/go-logr/stdr'],
+      abandonmentThresholdDays: null // Never mark as abandoned
+    }
+  ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Replace stdr adapter with a custom slog-based logr implementation and update the operator image reference.

Enhancements:
- Introduce slogLogger in internal/logger to bridge Go's slog.Logger with logr consumers
- Remove dependency on go-logr/stdr and custom slogStdLogger in favor of the new internal adapter

Deployment:
- Update kustomization image name to heartbeats-operator and set tag to test

Chores:
- Remove direct github.com/go-logr/stdr requirement from go.mod