### PR TITLE
fix: add workload version labels to installer output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,13 +185,21 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 # Define ignore-not-found with a default value
 IGNORE_NOT_FOUND ?= false
 
+define render-versioned-manifest
+	image_no_digest="$${IMG%%@*}"; \
+	last_segment="$${image_no_digest##*/}"; \
+	case "$$last_segment" in \
+		*:* ) version="$${last_segment##*:}" ;; \
+		* ) version="latest" ;; \
+	esac; \
+	$(KUSTOMIZE) build $(1) | sed "s|app.kubernetes.io/version: __APP_VERSION__|app.kubernetes.io/version: $$version|g"
+endef
+
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" > dist/install.yaml
+	@$(call render-versioned-manifest,config/default) > dist/install.yaml
 
 ##@ Deployment
 
@@ -206,16 +214,12 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
+	@$(call render-versioned-manifest,config/default) | $(KUBECTL) apply -f -
 
 .PHONY: deploy-test
 deploy-test: manifests kustomize ## Deploy controller for testing (using local image) to the K8s cluster.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	$(KUSTOMIZE) build config/e2e | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
+	@$(call render-versioned-manifest,config/e2e) | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,9 @@ IGNORE_NOT_FOUND ?= false
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" > dist/install.yaml
 
 ##@ Deployment
 
@@ -204,12 +206,16 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
 
 .PHONY: deploy-test
 deploy-test: manifests kustomize ## Deploy controller for testing (using local image) to the K8s cluster.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/e2e | $(KUBECTL) apply -f -
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	$(KUSTOMIZE) build config/e2e | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: heartbeats-operator
-    app.kubernetes.io/version: latest
+    app.kubernetes.io/version: __APP_VERSION__
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -16,6 +16,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: heartbeats-operator
+    app.kubernetes.io/version: __APP_VERSION__
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
@@ -30,7 +31,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: heartbeats-operator
-        app.kubernetes.io/version: latest
+        app.kubernetes.io/version: __APP_VERSION__
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: heartbeats-operator
+    app.kubernetes.io/version: latest
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -29,6 +30,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: heartbeats-operator
+        app.kubernetes.io/version: latest
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.


### PR DESCRIPTION
## Summary
- add `app.kubernetes.io/version` to the namespace, Deployment, and pod-template metadata for the controller workload
- derive the rendered label value from the `IMG` tag, defaulting to `latest` when no tag is present
- use a dedicated `__APP_VERSION__` placeholder and a shared render helper to avoid broad manifest rewrites

## Verification
- `make build-installer IMG=ghcr.io/siutsin/heartbeats:v9.9.9`
- `make build-installer IMG=ghcr.io/siutsin/heartbeats`

## Scope
- this is intentionally limited to workload metadata used by Kubernetes/Kiali views, not every RBAC or service object
