### PR TITLE
chore: tighten golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,9 @@ linters:
       - path: ^test/
         linters:
           - noctx
+      - path: ^cmd/main\.go$
+        linters:
+          - misspell
       - path: (.+)_test\.go
         linters:
           - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,51 +1,85 @@
 version: "2"
+
 run:
   allow-parallel-runners: true
+  relative-path-mode: gomod
+  tests: true
+
 linters:
-  default: none
+  default: standard
   enable:
-  - copyloopvar
-  - dupl
-  - errcheck
-  - ginkgolinter
-  - goconst
-  - gocyclo
-  - govet
-  - ineffassign
-  - lll
-  - misspell
-  - nakedret
-  - prealloc
-  - revive
-  - staticcheck
-  - unconvert
-  - unparam
-  - unused
+    - bodyclose # Detect leaked HTTP response bodies.
+    - copyloopvar # Catch unsafe loop variable copies and captures.
+    - durationcheck # Flag invalid duration arithmetic.
+    - errorlint # Enforce modern wrapped-error handling.
+    - ginkgolinter # Enforce correct Ginkgo and Gomega test usage.
+    - misspell # Catch common spelling mistakes using UK English.
+    - noctx # Require context-aware APIs in non-test code paths.
+    - nolintlint # Keep nolint directives specific and justified.
+    - revive # Provide configurable, actively maintained style and correctness checks.
+    - testifylint # Catch misuse of testify assertions in tests.
+    - unconvert # Remove unnecessary type conversions.
+    - unparam # Find parameters that are never used by callees.
   settings:
+    errcheck:
+      check-blank: true
+      check-type-assertions: true
+    govet:
+      enable:
+        - nilness
+        - shadow
+    misspell:
+      locale: UK
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
     revive:
       rules:
-      - name: comment-spacings
+        - name: comment-spacings
+        - name: indent-error-flow
+        - name: unexported-return
+          disabled: true
+    testifylint:
+      enable-all: true
   exclusions:
     generated: lax
     rules:
-    - linters:
-      - lll
-      path: api/*
-    - linters:
-      - dupl
-      - lll
-      path: internal/*
+      - path: ^api/
+        linters:
+          - lll
+      - path: ^test/mocks/
+        linters:
+          - revive
+          - testifylint
+      - path: ^test/
+        linters:
+          - noctx
+      - path: (.+)_test\.go
+        linters:
+          - dupl
+          - goconst
+          - lll
     paths:
-    - third_party$
-    - builtin$
-    - examples$
+      - third_party$
+      - builtin$
+      - examples$
+
 formatters:
   enable:
-  - gofmt
-  - goimports
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+    goimports:
+      local-prefixes:
+        - github.com/siutsin/heartbeats
   exclusions:
     generated: lax
     paths:
-    - third_party$
-    - builtin$
-    - examples$
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -185,13 +185,21 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 # Define ignore-not-found with a default value
 IGNORE_NOT_FOUND ?= false
 
+define render-versioned-manifest
+	image_no_digest="$${IMG%%@*}"; \
+	last_segment="$${image_no_digest##*/}"; \
+	case "$$last_segment" in \
+		*:* ) version="$${last_segment##*:}" ;; \
+		* ) version="latest" ;; \
+	esac; \
+	$(KUSTOMIZE) build $(1) | sed "s|app.kubernetes.io/version: __APP_VERSION__|app.kubernetes.io/version: $$version|g"
+endef
+
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" > dist/install.yaml
+	@$(call render-versioned-manifest,config/default) > dist/install.yaml
 
 ##@ Deployment
 
@@ -206,16 +214,12 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
+	@$(call render-versioned-manifest,config/default) | $(KUBECTL) apply -f -
 
 .PHONY: deploy-test
 deploy-test: manifests kustomize ## Deploy controller for testing (using local image) to the K8s cluster.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	@image_no_digest="$${IMG%%@*}"; \
-	version="$${image_no_digest##*:}"; \
-	$(KUSTOMIZE) build config/e2e | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
+	@$(call render-versioned-manifest,config/e2e) | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,9 @@ IGNORE_NOT_FOUND ?= false
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" > dist/install.yaml
 
 ##@ Deployment
 
@@ -204,12 +206,16 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	$(KUSTOMIZE) build config/default | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
 
 .PHONY: deploy-test
 deploy-test: manifests kustomize ## Deploy controller for testing (using local image) to the K8s cluster.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/e2e | $(KUBECTL) apply -f -
+	@image_no_digest="$${IMG%%@*}"; \
+	version="$${image_no_digest##*:}"; \
+	$(KUSTOMIZE) build config/e2e | sed "s|app.kubernetes.io/version: latest|app.kubernetes.io/version: $$version|g" | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/api/v1alpha1/heartbeat_types.go
+++ b/api/v1alpha1/heartbeat_types.go
@@ -24,7 +24,7 @@ import (
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// NOTE: json tags are required. Any new fields you add must have json tags for the fields to be serialised.
 
 // EndpointSecretRef defines a reference to a Kubernetes secret containing endpoint information
 type EndpointSecretRef struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -142,7 +142,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 
 	if len(webhookCertPath) > 0 {
-		setupLog.Info("Initialising webhook certificate watcher using provided certificates",
+		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
 			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
 
 		var err error
@@ -151,7 +151,7 @@ func main() {
 			filepath.Join(webhookCertPath, webhookCertKey),
 		)
 		if err != nil {
-			setupLog.Error(err, "Failed to initialise webhook certificate watcher")
+			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
 			os.Exit(1)
 		}
 
@@ -191,7 +191,7 @@ func main() {
 	// managed by cert-manager for the metrics server.
 	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
 	if len(metricsCertPath) > 0 {
-		setupLog.Info("Initialising metrics certificate watcher using provided certificates",
+		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
 
 		var err error
@@ -200,7 +200,7 @@ func main() {
 			filepath.Join(metricsCertPath, metricsCertKey),
 		)
 		if err != nil {
-			setupLog.Error(err, "Failed to initialise metrics certificate watcher")
+			setupLog.Error(err, "Failed to initialize metrics certificate watcher")
 			os.Exit(1)
 		}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func ParseFlags() {
 	flag.Parse()
 }
 
-// nolint:gocyclo
+//nolint:gocyclo // main wires controller-runtime options and flag setup in one place.
 func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
@@ -142,7 +142,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 
 	if len(webhookCertPath) > 0 {
-		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
+		setupLog.Info("Initialising webhook certificate watcher using provided certificates",
 			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
 
 		var err error
@@ -151,7 +151,7 @@ func main() {
 			filepath.Join(webhookCertPath, webhookCertKey),
 		)
 		if err != nil {
-			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
+			setupLog.Error(err, "Failed to initialise webhook certificate watcher")
 			os.Exit(1)
 		}
 
@@ -191,7 +191,7 @@ func main() {
 	// managed by cert-manager for the metrics server.
 	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
 	if len(metricsCertPath) > 0 {
-		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
+		setupLog.Info("Initialising metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
 
 		var err error
@@ -200,7 +200,7 @@ func main() {
 			filepath.Join(metricsCertPath, metricsCertKey),
 		)
 		if err != nil {
-			setupLog.Error(err, "Failed to initialize metrics certificate watcher")
+			setupLog.Error(err, "Failed to initialise metrics certificate watcher")
 			os.Exit(1)
 		}
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: heartbeats-operator
-    app.kubernetes.io/version: latest
+    app.kubernetes.io/version: __APP_VERSION__
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -16,6 +16,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: heartbeats-operator
+    app.kubernetes.io/version: __APP_VERSION__
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
@@ -30,7 +31,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: heartbeats-operator
-        app.kubernetes.io/version: latest
+        app.kubernetes.io/version: __APP_VERSION__
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: heartbeats-operator
+    app.kubernetes.io/version: latest
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -29,6 +30,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: heartbeats-operator
+        app.kubernetes.io/version: latest
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+
 	"github.com/siutsin/heartbeats/internal/controller"
 )
 

--- a/internal/controller/health_checker.go
+++ b/internal/controller/health_checker.go
@@ -375,7 +375,7 @@ func (h *DefaultHealthChecker) handleReportResponse(
 	reportURL, reportMethod, healthStatus string,
 	log logr.Logger,
 ) bool {
-	if reportResp != nil && reportResp.StatusCode >= 200 && reportResp.StatusCode < 300 {
+	if reportResp.StatusCode >= 200 && reportResp.StatusCode < 300 {
 		log.V(1).Info("Report request successful",
 			"report_url", reportURL,
 			"report_method", reportMethod,

--- a/internal/controller/health_checker.go
+++ b/internal/controller/health_checker.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -94,7 +95,8 @@ func (h *DefaultHealthChecker) executeRequest(req *http.Request, log logr.Logger
 
 // handleRequestError processes and categorises request errors.
 func (h *DefaultHealthChecker) handleRequestError(req *http.Request, log logr.Logger, err error, attempt int) error {
-	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		log.Error(err, "Request timeout",
 			"method", req.Method,
 			"endpoint", req.URL.String(),
@@ -315,6 +317,15 @@ func (h *DefaultHealthChecker) executeReportRequest(
 		h.logReportRequestError(err, reportURL, reportMethod, healthStatus, log)
 		return false
 	}
+	defer func() {
+		if closeErr := reportResp.Body.Close(); closeErr != nil {
+			log.Error(closeErr, "Failed to close report response body",
+				"report_url", reportURL,
+				"report_method", reportMethod,
+				"health_status", healthStatus,
+			)
+		}
+	}()
 
 	return h.handleReportResponse(reportResp, reportURL, reportMethod, healthStatus, log)
 }

--- a/internal/controller/health_checker_test.go
+++ b/internal/controller/health_checker_test.go
@@ -118,7 +118,9 @@ func TestCheckEndpointHealth_HealthyEndpoint(t *testing.T) {
 			serverBehavior: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"healthy":true,"lastStatus":200,"message":"Endpoint is healthy"}`))
+				if _, err := w.Write([]byte(`{"healthy":true,"lastStatus":200,"message":"Endpoint is healthy"}`)); err != nil {
+					t.Errorf("failed to write response body: %v", err)
+				}
 			},
 		},
 	}

--- a/internal/controller/heartbeat_controller.go
+++ b/internal/controller/heartbeat_controller.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -28,10 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/go-logr/logr"
 	monitoringv1alpha1 "github.com/siutsin/heartbeats/api/v1alpha1"
 	"github.com/siutsin/heartbeats/internal/logger"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -85,7 +85,7 @@ func (r *HeartbeatReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Parse the interval from the heartbeat spec
 	interval, err := ParseInterval(heartbeat.Spec.Interval)
 	if err != nil {
-		logger.Error(heartbeatLog, "Failed to parse interval", err, map[string]interface{}{
+		logger.Error(heartbeatLog, "Failed to parse interval", err, map[string]any{
 			"interval": heartbeat.Spec.Interval,
 		})
 		// Fall back to config default on parsing error
@@ -97,7 +97,7 @@ func (r *HeartbeatReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.handleReconcileError(ctx, heartbeat, processErr, interval)
 	}
 
-	completionFields := map[string]interface{}{
+	completionFields := map[string]any{
 		"requeue_after": interval,
 		"interval":      heartbeat.Spec.Interval,
 	}
@@ -111,12 +111,12 @@ func runStep[T any](
 	name string,
 	f func() (T, error),
 ) (T, error) {
-	logger.Info(log, "Starting step", map[string]interface{}{"step": name})
+	logger.Info(log, "Starting step", map[string]any{"step": name})
 	out, err := f()
 	if err != nil {
-		logger.Error(log, "Step failed", err, map[string]interface{}{"step": name})
+		logger.Error(log, "Step failed", err, map[string]any{"step": name})
 	} else {
-		logger.Info(log, "Step completed", map[string]interface{}{"step": name})
+		logger.Info(log, "Step completed", map[string]any{"step": name})
 	}
 	return out, err
 }
@@ -128,7 +128,7 @@ func (r *HeartbeatReconciler) processHeartbeat(
 	req ctrl.Request,
 	heartbeatLog logr.Logger,
 ) error {
-	logger.Info(heartbeatLog, "Resource fetched successfully", map[string]interface{}{
+	logger.Info(heartbeatLog, "Resource fetched successfully", map[string]any{
 		"target_endpoint_key":    heartbeat.Spec.EndpointsSecret.TargetEndpointKey,
 		"healthy_endpoint_key":   heartbeat.Spec.EndpointsSecret.HealthyEndpointKey,
 		"unhealthy_endpoint_key": heartbeat.Spec.EndpointsSecret.UnhealthyEndpointKey,
@@ -185,7 +185,7 @@ func (r *HeartbeatReconciler) processHeartbeat(
 				logger.Error(heartbeatLog, errMsgFailedToFetchResource, extractErr, nil)
 				return monitoringv1alpha1.EndpointsSecret{}, extractErr
 			}
-			reportFields := map[string]interface{}{
+			reportFields := map[string]any{
 				"healthy_endpoint":   endpoints.HealthyEndpointKey,
 				"unhealthy_endpoint": endpoints.UnhealthyEndpointKey,
 			}
@@ -200,7 +200,7 @@ func (r *HeartbeatReconciler) processHeartbeat(
 	// Step 5: Perform health check and report status
 	_, err = runStep(heartbeatLog, "healthCheckAndReport", func() (struct{}, error) {
 		if checkErr := r.performHealthCheckAndReport(ctx, heartbeat, targetEndpoint, reportEndpointsSecret); checkErr != nil {
-			healthCheckFields := map[string]interface{}{
+			healthCheckFields := map[string]any{
 				"endpoint": targetEndpoint,
 			}
 			logger.Error(
@@ -226,7 +226,7 @@ func (r *HeartbeatReconciler) handleReconcileError(
 ) (ctrl.Result, error) {
 	l := logger.WithHeartbeat(ctx, logNameHeartbeatReconciler, heartbeat.Namespace, heartbeat.Name)
 
-	logger.Error(l, "Reconciliation error occurred", err, map[string]interface{}{
+	logger.Error(l, "Reconciliation error occurred", err, map[string]any{
 		"requeue_after": interval,
 	})
 

--- a/internal/controller/heartbeat_controller_test.go
+++ b/internal/controller/heartbeat_controller_test.go
@@ -59,9 +59,10 @@ type testCase struct {
 // It uses table-driven tests to verify various scenarios including healthy endpoints,
 // unhealthy endpoints, invalid configurations, and error conditions.
 func TestHeartbeatReconciler(t *testing.T) {
+	g := gomega.NewWithT(t)
 	scheme := runtime.NewScheme()
-	_ = monitoringv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	g.Expect(monitoringv1alpha1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
 
 	tests := []testCase{
 		{
@@ -231,8 +232,8 @@ func TestConcurrentReconciliationNotBlocked(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	scheme := runtime.NewScheme()
-	_ = monitoringv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	g.Expect(monitoringv1alpha1.AddToScheme(scheme)).To(gomega.Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(gomega.Succeed())
 
 	// Create multiple heartbeats and secrets
 	failingHeartbeat := &monitoringv1alpha1.Heartbeat{
@@ -327,26 +328,26 @@ func TestConcurrentReconciliationNotBlocked(t *testing.T) {
 	startTime := time.Now()
 
 	// Run reconciliations concurrently (simulating what the controller does with MaxConcurrentReconciles > 1)
-	done := make(chan struct{})
+	errCh := make(chan error, 2)
 	go func() {
-		_, _ = reconciler.Reconcile(context.Background(), ctrl.Request{
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: "failing-heartbeat", Namespace: testNamespace},
 		})
 		failingCompleted = time.Now()
-		done <- struct{}{}
+		errCh <- err
 	}()
 
 	go func() {
-		_, _ = reconciler.Reconcile(context.Background(), ctrl.Request{
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: "healthy-heartbeat", Namespace: testNamespace},
 		})
 		healthyCompleted = time.Now()
-		done <- struct{}{}
+		errCh <- err
 	}()
 
 	// Wait for both to complete
-	<-done
-	<-done
+	g.Expect(<-errCh).NotTo(gomega.HaveOccurred())
+	g.Expect(<-errCh).NotTo(gomega.HaveOccurred())
 
 	// Verify healthy heartbeat completed significantly before failing heartbeat
 	healthyDuration := healthyCompleted.Sub(startTime)

--- a/internal/controller/status_updater.go
+++ b/internal/controller/status_updater.go
@@ -3,12 +3,12 @@ package controller
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	monitoringv1alpha1 "github.com/siutsin/heartbeats/api/v1alpha1"
 	"github.com/siutsin/heartbeats/internal/logger"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // StatusUpdater handles updating the status of Heartbeat resources.
@@ -108,7 +108,7 @@ func (u *StatusUpdater) UpdateMissingKeyStatus(
 	key string,
 ) error {
 	log := log.FromContext(ctx)
-	logger.Error(log, ErrMissingRequiredKey, nil, map[string]interface{}{
+	logger.Error(log, ErrMissingRequiredKey, nil, map[string]any{
 		"key": key,
 	})
 	return u.UpdateStatus(

--- a/internal/controller/status_updater_test.go
+++ b/internal/controller/status_updater_test.go
@@ -22,7 +22,9 @@ import (
 //   - *runtime.Scheme: A scheme with monitoring API types registered
 func setupScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	_ = monitoringv1alpha1.AddToScheme(scheme)
+	if err := monitoringv1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
 	return scheme
 }
 

--- a/internal/controller/status_updater_test.go
+++ b/internal/controller/status_updater_test.go
@@ -20,10 +20,12 @@ import (
 //
 // Returns:
 //   - *runtime.Scheme: A scheme with monitoring API types registered
-func setupScheme() *runtime.Scheme {
+func setupScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
 	scheme := runtime.NewScheme()
 	if err := monitoringv1alpha1.AddToScheme(scheme); err != nil {
-		panic(err)
+		t.Fatalf("add monitoring API to scheme: %v", err)
 	}
 	return scheme
 }
@@ -46,13 +48,16 @@ func createTestHeartbeat() *monitoringv1alpha1.Heartbeat {
 // This helper function reduces code duplication in tests.
 //
 // Parameters:
+//   - t: The test instance used for helper failures
 //   - heartbeat: The heartbeat object to include in the fake client
 //
 // Returns:
 //   - client.Client: A fake client with the heartbeat registered
-func createTestClient(heartbeat *monitoringv1alpha1.Heartbeat) client.Client {
+func createTestClient(t *testing.T, heartbeat *monitoringv1alpha1.Heartbeat) client.Client {
+	t.Helper()
+
 	return fake.NewClientBuilder().
-		WithScheme(setupScheme()).
+		WithScheme(setupScheme(t)).
 		WithObjects(heartbeat).
 		WithStatusSubresource(heartbeat).
 		Build()
@@ -63,7 +68,7 @@ func createTestClient(heartbeat *monitoringv1alpha1.Heartbeat) client.Client {
 func TestNewStatusUpdater(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	client := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
+	client := fake.NewClientBuilder().WithScheme(setupScheme(t)).Build()
 	updater := controller.NewStatusUpdater(client)
 
 	g.Expect(updater).NotTo(gomega.BeNil())
@@ -83,7 +88,7 @@ func TestUpdateStatus_Basic(t *testing.T) {
 	}
 
 	client := fake.NewClientBuilder().
-		WithScheme(setupScheme()).
+		WithScheme(setupScheme(t)).
 		WithObjects(heartbeat).
 		WithStatusSubresource(heartbeat).
 		Build()
@@ -175,7 +180,7 @@ func runErrorConditionTest(t *testing.T, tt struct {
 	g := gomega.NewWithT(t)
 
 	heartbeat := createTestHeartbeat()
-	client := createTestClient(heartbeat)
+	client := createTestClient(t, heartbeat)
 	updater := controller.NewStatusUpdater(client)
 
 	err := tt.updateFunc(updater, context.Background(), heartbeat)
@@ -193,7 +198,7 @@ func TestUpdateHealthStatus_HealthyEndpoint(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	heartbeat := createTestHeartbeat()
-	client := createTestClient(heartbeat)
+	client := createTestClient(t, heartbeat)
 	updater := controller.NewStatusUpdater(client)
 
 	err := updater.UpdateHealthStatus(
@@ -240,7 +245,7 @@ func TestUpdateHealthStatus_UnhealthyEndpoint(t *testing.T) {
 			g := gomega.NewWithT(t)
 
 			heartbeat := createTestHeartbeat()
-			client := createTestClient(heartbeat)
+			client := createTestClient(t, heartbeat)
 			updater := controller.NewStatusUpdater(client)
 
 			err := updater.UpdateHealthStatus(
@@ -267,7 +272,7 @@ func TestUpdateHealthStatus_ReportFailure(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	heartbeat := createTestHeartbeat()
-	client := createTestClient(heartbeat)
+	client := createTestClient(t, heartbeat)
 	updater := controller.NewStatusUpdater(client)
 
 	err := updater.UpdateHealthStatus(

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -26,7 +26,7 @@ func WithHeartbeat(ctx context.Context, component string, namespace, name string
 }
 
 // Info logs an informational message with optional additional fields.
-func Info(log logr.Logger, message string, additionalFields map[string]interface{}) {
+func Info(log logr.Logger, message string, additionalFields map[string]any) {
 	if additionalFields != nil {
 		log.V(1).Info(message, additionalFields)
 	} else {
@@ -35,7 +35,7 @@ func Info(log logr.Logger, message string, additionalFields map[string]interface
 }
 
 // Error logs an error message with optional additional fields.
-func Error(log logr.Logger, message string, err error, additionalFields map[string]interface{}) {
+func Error(log logr.Logger, message string, err error, additionalFields map[string]any) {
 	if additionalFields != nil {
 		log.Error(err, message, additionalFields)
 	} else {
@@ -72,7 +72,7 @@ func (s *slogLogger) Enabled(level int) bool {
 	return level <= s.minLogLevel
 }
 
-func (s *slogLogger) Info(_ int, msg string, keysAndValues ...interface{}) {
+func (s *slogLogger) Info(_ int, msg string, keysAndValues ...any) {
 	attrs := make([]any, 0, len(keysAndValues))
 	for i := 0; i < len(keysAndValues); i += 2 {
 		if i+1 < len(keysAndValues) {
@@ -85,7 +85,7 @@ func (s *slogLogger) Info(_ int, msg string, keysAndValues ...interface{}) {
 	s.logger.Info(msg, attrs...)
 }
 
-func (s *slogLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (s *slogLogger) Error(err error, msg string, keysAndValues ...any) {
 	attrs := make([]any, 0, len(keysAndValues)+2)
 
 	// Check if "error" key already exists in keysAndValues to avoid collision
@@ -113,7 +113,7 @@ func (s *slogLogger) Error(err error, msg string, keysAndValues ...interface{}) 
 	s.logger.Error(msg, attrs...)
 }
 
-func (s *slogLogger) WithValues(keysAndValues ...interface{}) logr.LogSink {
+func (s *slogLogger) WithValues(keysAndValues ...any) logr.LogSink {
 	attrs := make([]any, 0, len(keysAndValues))
 	for i := 0; i < len(keysAndValues); i += 2 {
 		if i+1 < len(keysAndValues) {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -21,25 +21,25 @@ type testLogSink struct {
 type infoCall struct {
 	level int
 	msg   string
-	keys  []interface{}
+	keys  []any
 }
 
 type errorCall struct {
 	err  error
 	msg  string
-	keys []interface{}
+	keys []any
 }
 
 func (t *testLogSink) Init(_ logr.RuntimeInfo) {}
 func (t *testLogSink) Enabled(_ int) bool      { return true }
-func (t *testLogSink) Info(level int, msg string, keysAndValues ...interface{}) {
+func (t *testLogSink) Info(level int, msg string, keysAndValues ...any) {
 	t.infoCalls = append(t.infoCalls, infoCall{level: level, msg: msg, keys: keysAndValues})
 }
-func (t *testLogSink) Error(err error, msg string, keysAndValues ...interface{}) {
+func (t *testLogSink) Error(err error, msg string, keysAndValues ...any) {
 	t.errorCalls = append(t.errorCalls, errorCall{err: err, msg: msg, keys: keysAndValues})
 }
-func (t *testLogSink) WithValues(_ ...interface{}) logr.LogSink { return t }
-func (t *testLogSink) WithName(_ string) logr.LogSink           { return t }
+func (t *testLogSink) WithValues(_ ...any) logr.LogSink { return t }
+func (t *testLogSink) WithName(_ string) logr.LogSink   { return t }
 
 func TestWithRequest(t *testing.T) {
 	g := gomega.NewWithT(t)
@@ -61,7 +61,7 @@ func TestInfo(t *testing.T) {
 	tests := []struct {
 		name             string
 		message          string
-		additionalFields map[string]interface{}
+		additionalFields map[string]any
 		description      string
 	}{
 		{
@@ -73,7 +73,7 @@ func TestInfo(t *testing.T) {
 		{
 			name:    "with additional fields",
 			message: "test message with fields",
-			additionalFields: map[string]interface{}{
+			additionalFields: map[string]any{
 				"key1": "value1",
 				"key2": "value2",
 			},
@@ -109,7 +109,7 @@ func TestError(t *testing.T) {
 		name             string
 		message          string
 		err              error
-		additionalFields map[string]interface{}
+		additionalFields map[string]any
 		description      string
 	}{
 		{
@@ -123,7 +123,7 @@ func TestError(t *testing.T) {
 			name:    "with additional fields",
 			message: "test error message with fields",
 			err:     errors.New("test error"),
-			additionalFields: map[string]interface{}{
+			additionalFields: map[string]any{
 				"key1": "value1",
 				"key2": "value2",
 			},
@@ -163,7 +163,7 @@ func TestLogEndpointExtractionError(t *testing.T) {
 		endpointType      string
 		key               string
 		err               error
-		expectedKeys      []interface{}
+		expectedKeys      []any
 		description       string
 	}{
 		{
@@ -174,7 +174,7 @@ func TestLogEndpointExtractionError(t *testing.T) {
 			endpointType:      "healthy",
 			key:               "test-key",
 			err:               errors.New("test extraction error"),
-			expectedKeys: []interface{}{
+			expectedKeys: []any{
 				"namespace", "test-namespace", "name", "test-name",
 				"healthy_endpoint_key", "test-key",
 			},
@@ -188,7 +188,7 @@ func TestLogEndpointExtractionError(t *testing.T) {
 			endpointType:      "unhealthy",
 			key:               "other-key",
 			err:               errors.New("test extraction error"),
-			expectedKeys: []interface{}{
+			expectedKeys: []any{
 				"namespace", "other-namespace", "name", "other-name",
 				"unhealthy_endpoint_key", "other-key",
 			},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"os/exec"
 	"testing"
@@ -71,7 +70,7 @@ var _ = ginkgo.AfterSuite(func() {
 // then creates a new cluster using the configuration file.
 func setupKindCluster() {
 	ginkgo.By("deleting any existing Kind cluster")
-	cmd := exec.CommandContext(context.Background(), "kind", "delete", "cluster")
+	cmd := exec.Command("kind", "delete", "cluster")
 	_, err := utils.Run(cmd)
 	if err != nil {
 		// If the cluster doesn't exist, that's fine
@@ -81,7 +80,7 @@ func setupKindCluster() {
 	}
 
 	ginkgo.By("creating a new Kind cluster")
-	cmd = exec.CommandContext(context.Background(), "kind", "create", "cluster", "--config", "test/e2e/kind-config.yaml")
+	cmd = exec.Command("kind", "create", "cluster", "--config", "test/e2e/kind-config.yaml")
 	_, err = utils.Run(cmd)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), "Failed to create Kind cluster")
 }
@@ -90,7 +89,7 @@ func setupKindCluster() {
 // This ensures that the Kind cluster has access to the latest version of the operator for testing.
 func buildAndLoadOperatorImage() {
 	ginkgo.By("building the manager(Operator) image")
-	cmd := exec.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 	_, err := utils.Run(cmd)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), "Failed to build the manager(Operator) image")
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,12 +20,14 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	"github.com/siutsin/heartbeats/test/utils"
 )
 
@@ -69,17 +71,17 @@ var _ = ginkgo.AfterSuite(func() {
 // then creates a new cluster using the configuration file.
 func setupKindCluster() {
 	ginkgo.By("deleting any existing Kind cluster")
-	cmd := exec.Command("kind", "delete", "cluster")
+	cmd := exec.CommandContext(context.Background(), "kind", "delete", "cluster")
 	_, err := utils.Run(cmd)
 	if err != nil {
 		// If the cluster doesn't exist, that's fine
-		if _, err := fmt.Fprintf(ginkgo.GinkgoWriter, "No existing cluster to delete\n"); err != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to write to GinkgoWriter: %v", err))
+		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "No existing cluster to delete\n"); writeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to write to GinkgoWriter: %v", writeErr))
 		}
 	}
 
 	ginkgo.By("creating a new Kind cluster")
-	cmd = exec.Command("kind", "create", "cluster", "--config", "test/e2e/kind-config.yaml")
+	cmd = exec.CommandContext(context.Background(), "kind", "create", "cluster", "--config", "test/e2e/kind-config.yaml")
 	_, err = utils.Run(cmd)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), "Failed to create Kind cluster")
 }
@@ -88,7 +90,7 @@ func setupKindCluster() {
 // This ensures that the Kind cluster has access to the latest version of the operator for testing.
 func buildAndLoadOperatorImage() {
 	ginkgo.By("building the manager(Operator) image")
-	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+	cmd := exec.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 	_, err := utils.Run(cmd)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), "Failed to build the manager(Operator) image")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,6 +97,13 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 	})
 })
 
+// writeDiagnosticf writes diagnostic output to the Ginkgo writer without changing test control flow.
+// Diagnostic logging should never mask the original test failure it is trying to explain.
+func writeDiagnosticf(format string, args ...any) {
+	//nolint:errcheck // Diagnostic writer failures are not actionable and must not replace the original test failure.
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, format, args...)
+}
+
 // collectManagerDiagnosticInfo gathers logs, events, and pod descriptions for debugging failed manager tests.
 // This function is called when a test fails to provide diagnostic information.
 //
@@ -107,48 +114,36 @@ func collectManagerDiagnosticInfo(controllerPodName string) {
 	cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 	controllerLogs, err := utils.Run(cmd)
 	if err == nil {
-		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Controller logs:\n %s", controllerLogs); writeErr != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to write controller logs: %v", writeErr))
-		}
+		writeDiagnosticf("Controller logs:\n %s", controllerLogs)
 	} else {
-		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Controller logs: %s", err); writeErr != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to write controller log error: %v", writeErr))
-		}
+		writeDiagnosticf("Failed to get Controller logs: %s", err)
 	}
 
 	ginkgo.By("Fetching Kubernetes events")
 	cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
 	eventsOutput, err := utils.Run(cmd)
 	if err == nil {
-		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Kubernetes events:\n%s", eventsOutput); writeErr != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to write Kubernetes events: %v", writeErr))
-		}
+		writeDiagnosticf("Kubernetes events:\n%s", eventsOutput)
 	} else {
-		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Kubernetes events: %s", err); writeErr != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to write Kubernetes event error: %v", writeErr))
-		}
+		writeDiagnosticf("Failed to get Kubernetes events: %s", err)
 	}
 
 	ginkgo.By("Fetching curl-metrics logs")
 	cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
 	metricsOutput, err := utils.Run(cmd)
 	if err == nil {
-		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Metrics logs:\n %s", metricsOutput); writeErr != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to write metrics logs: %v", writeErr))
-		}
+		writeDiagnosticf("Metrics logs:\n %s", metricsOutput)
 	} else {
-		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get curl-metrics logs: %s", err); writeErr != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to write metrics log error: %v", writeErr))
-		}
+		writeDiagnosticf("Failed to get curl-metrics logs: %s", err)
 	}
 
 	ginkgo.By("Fetching controller manager pod description")
 	cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
 	podDescription, err := utils.Run(cmd)
 	if err == nil {
-		fmt.Println("Pod description:\n", podDescription)
+		writeDiagnosticf("Pod description:\n %s", podDescription)
 	} else {
-		fmt.Println("Failed to describe controller pod")
+		writeDiagnosticf("Failed to describe controller pod")
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/goccy/go-yaml"
@@ -57,7 +58,7 @@ var _ = ginkgo.Describe("Manager", ginkgo.Ordered, func() {
 	// BeforeAll sets up the test environment before any manager tests run.
 	// It configures the namespace with restricted security policy for testing.
 	ginkgo.BeforeAll(func() {
-		ginkgo.By("labeling the namespace to enforce the restricted security policy")
+		ginkgo.By("labelling the namespace to enforce the restricted security policy")
 		cmd := exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
 			"pod-security.kubernetes.io/enforce=restricted")
 		_, err := utils.Run(cmd)
@@ -106,27 +107,39 @@ func collectManagerDiagnosticInfo(controllerPodName string) {
 	cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 	controllerLogs, err := utils.Run(cmd)
 	if err == nil {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Controller logs:\n %s", controllerLogs)
+		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Controller logs:\n %s", controllerLogs); writeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to write controller logs: %v", writeErr))
+		}
 	} else {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Controller logs: %s", err)
+		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Controller logs: %s", err); writeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to write controller log error: %v", writeErr))
+		}
 	}
 
 	ginkgo.By("Fetching Kubernetes events")
 	cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
 	eventsOutput, err := utils.Run(cmd)
 	if err == nil {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
+		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Kubernetes events:\n%s", eventsOutput); writeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to write Kubernetes events: %v", writeErr))
+		}
 	} else {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Kubernetes events: %s", err)
+		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get Kubernetes events: %s", err); writeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to write Kubernetes event error: %v", writeErr))
+		}
 	}
 
 	ginkgo.By("Fetching curl-metrics logs")
 	cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
 	metricsOutput, err := utils.Run(cmd)
 	if err == nil {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
+		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Metrics logs:\n %s", metricsOutput); writeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to write metrics logs: %v", writeErr))
+		}
 	} else {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
+		if _, writeErr := fmt.Fprintf(ginkgo.GinkgoWriter, "Failed to get curl-metrics logs: %s", err); writeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to write metrics log error: %v", writeErr))
+		}
 	}
 
 	ginkgo.By("Fetching controller manager pod description")
@@ -306,8 +319,8 @@ func serviceAccountToken() (string, error) {
 		return "", err
 	}
 	defer func() {
-		if err := os.Remove(tokenRequestFile); err != nil {
-			ginkgo.Fail(fmt.Sprintf("Failed to remove token request file: %v", err))
+		if removeErr := os.Remove(tokenRequestFile); removeErr != nil {
+			ginkgo.Fail(fmt.Sprintf("Failed to remove token request file: %v", removeErr))
 		}
 	}()
 
@@ -320,13 +333,13 @@ func serviceAccountToken() (string, error) {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to create token: %v", err)
+		return "", fmt.Errorf("failed to create token: %w", err)
 	}
 
 	// Parse the JSON output to extract the token
 	var token tokenRequest
 	if err := json.Unmarshal(output, &token); err != nil {
-		return "", fmt.Errorf("failed to parse token response: %v", err)
+		return "", fmt.Errorf("failed to parse token response: %w", err)
 	}
 
 	if token.Status.Token == "" {
@@ -468,9 +481,15 @@ func createInitialHealthySecret(secretName string) {
 func cleanupHeartbeatResources(heartbeatName string) {
 	ginkgo.By("deleting the Heartbeat resources")
 	cmd := exec.Command("kubectl", "delete", "heartbeat", heartbeatName, "-n", namespace)
-	_, _ = utils.Run(cmd)
+	output, err := utils.Run(cmd)
+	if err != nil && !strings.Contains(output, "NotFound") {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to delete healthy heartbeat")
+	}
 	cmd = exec.Command("kubectl", "delete", "heartbeat", heartbeatName+"-unhealthy", "-n", namespace)
-	_, _ = utils.Run(cmd)
+	output, err = utils.Run(cmd)
+	if err != nil && !strings.Contains(output, "NotFound") {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to delete unhealthy heartbeat")
+	}
 }
 
 // createHealthyHeartbeat creates a Heartbeat resource that references the healthy endpoints secret.
@@ -611,10 +630,10 @@ func createMissingKeysSecret(secretName string) {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// Parse the YAML and modify it to have empty data
-	var secretYAML map[string]interface{}
+	var secretYAML map[string]any
 	err = yaml.Unmarshal([]byte(output), &secretYAML)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	secretYAML["data"] = map[string]interface{}{}
+	secretYAML["data"] = map[string]any{}
 
 	// Convert back to YAML
 	modifiedOutput, err := yaml.Marshal(secretYAML)

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,6 @@ package utils
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -47,9 +46,9 @@ const (
 )
 
 // writeGinkgoWriterf writes formatted output to the Ginkgo writer.
-func writeGinkgoWriterf(format string, args ...any) error {
-	_, err := fmt.Fprintf(ginkgo.GinkgoWriter, format, args...)
-	return err
+func writeGinkgoWriterf(format string, args ...any) {
+	//nolint:errcheck // GinkgoWriter failures are not actionable and must not affect test control flow.
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, format, args...)
 }
 
 // warnError logs a warning message when an error occurs during cleanup operations.
@@ -58,9 +57,7 @@ func writeGinkgoWriterf(format string, args ...any) error {
 // Parameters:
 //   - err: The error to log as a warning
 func warnError(err error) {
-	if writeErr := writeGinkgoWriterf("warning: %v\n", err); writeErr != nil {
-		return
-	}
+	writeGinkgoWriterf("warning: %v\n", err)
 }
 
 // Run executes the provided command within the project context.
@@ -81,16 +78,12 @@ func Run(cmd *exec.Cmd) (string, error) {
 	cmd.Dir = dir
 
 	if chdirErr := os.Chdir(cmd.Dir); chdirErr != nil {
-		if writeErr := writeGinkgoWriterf("chdir dir: %s\n", chdirErr); writeErr != nil {
-			return "", writeErr
-		}
+		writeGinkgoWriterf("chdir dir: %s\n", chdirErr)
 	}
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
-	if writeErr := writeGinkgoWriterf("running: %s\n", command); writeErr != nil {
-		return "", writeErr
-	}
+	writeGinkgoWriterf("running: %s\n", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("%s failed with error: (%w) %s", command, err, string(output))
@@ -117,16 +110,12 @@ func RunWithInput(cmd *exec.Cmd, input string) (string, error) {
 	cmd.Dir = dir
 
 	if chdirErr := os.Chdir(cmd.Dir); chdirErr != nil {
-		if writeErr := writeGinkgoWriterf("chdir dir: %s\n", chdirErr); writeErr != nil {
-			return "", writeErr
-		}
+		writeGinkgoWriterf("chdir dir: %s\n", chdirErr)
 	}
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
-	if writeErr := writeGinkgoWriterf("running: %s\n", command); writeErr != nil {
-		return "", writeErr
-	}
+	writeGinkgoWriterf("running: %s\n", command)
 
 	// Set up pipes for stdin, stdout, and stderr
 	stdin, err := cmd.StdinPipe()
@@ -169,7 +158,7 @@ func RunWithInput(cmd *exec.Cmd, input string) (string, error) {
 //   - error: Any error that occurred during installation
 func InstallPrometheusOperator() error {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "create", "-f", url)
+	cmd := exec.Command("kubectl", "create", "-f", url)
 	_, err := Run(cmd)
 	return err
 }
@@ -179,7 +168,7 @@ func InstallPrometheusOperator() error {
 // Errors during uninstallation are logged as warnings since they're not critical.
 func UninstallPrometheusOperator() {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", url)
+	cmd := exec.Command("kubectl", "delete", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -199,7 +188,7 @@ func IsPrometheusCRDsInstalled() bool {
 		"prometheusagents.monitoring.coreos.com",
 	}
 
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crds", "-o", "custom-columns=NAME:.metadata.name")
+	cmd := exec.Command("kubectl", "get", "crds", "-o", "custom-columns=NAME:.metadata.name")
 	output, err := Run(cmd)
 	if err != nil {
 		return false
@@ -221,7 +210,7 @@ func IsPrometheusCRDsInstalled() bool {
 // Errors during uninstallation are logged as warnings since they're not critical.
 func UninstallCertManager() {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", url)
+	cmd := exec.Command("kubectl", "delete", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -236,14 +225,14 @@ func UninstallCertManager() {
 //   - error: Any error that occurred during installation
 func InstallCertManager() error {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", url)
+	cmd := exec.Command("kubectl", "apply", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		return err
 	}
 
 	// Wait for cert-manager-webhook to be ready, which can take time if cert-manager
 	// was re-installed after uninstalling on a cluster.
-	cmd = exec.CommandContext(context.Background(), "kubectl", "wait", "deployment.apps/cert-manager-webhook",
+	cmd = exec.Command("kubectl", "wait", "deployment.apps/cert-manager-webhook",
 		"--for", "condition=Available",
 		"--namespace", "cert-manager",
 		"--timeout", "5m",
@@ -271,7 +260,7 @@ func IsCertManagerCRDsInstalled() bool {
 	}
 
 	// Execute the kubectl command to get all CRDs
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crds")
+	cmd := exec.Command("kubectl", "get", "crds")
 	output, err := Run(cmd)
 	if err != nil {
 		return false
@@ -328,24 +317,24 @@ func LoadImageToKindClusterWithName(name string) error {
 		}
 
 		// Tag image without localhost/ prefix
-		if _, runErr := Run(exec.CommandContext(context.Background(), "podman", "tag", podmanImage, name)); runErr != nil {
+		if _, runErr := Run(exec.Command("podman", "tag", podmanImage, name)); runErr != nil {
 			return runErr
 		}
 
 		// Save the non-prefixed image to tar
-		if _, runErr := Run(exec.CommandContext(context.Background(), "podman", "save", "-o", tmpFile.Name(), name)); runErr != nil {
+		if _, runErr := Run(exec.Command("podman", "save", "-o", tmpFile.Name(), name)); runErr != nil {
 			return runErr
 		}
 
 		// Copy tar into kind container
 		destPath := "/tmp/" + filepath.Base(tmpFile.Name())
 		containerName := cluster + "-control-plane"
-		if _, runErr := Run(exec.CommandContext(context.Background(), "podman", "cp", tmpFile.Name(), containerName+":"+destPath)); runErr != nil {
+		if _, runErr := Run(exec.Command("podman", "cp", tmpFile.Name(), containerName+":"+destPath)); runErr != nil {
 			return runErr
 		}
 
 		// Import image into containerd using ctr
-		_, err = Run(exec.CommandContext(context.Background(), "podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "import", destPath))
+		_, err = Run(exec.Command("podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "import", destPath))
 		if err != nil {
 			return err
 		}
@@ -353,13 +342,13 @@ func LoadImageToKindClusterWithName(name string) error {
 		// Tag the image to remove localhost/ prefix (containerd imports with localhost/ but k8s expects docker.io/library/)
 		localImage := "localhost/" + name
 		dockerImage := "docker.io/library/" + name
-		cmd := exec.CommandContext(context.Background(), "podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "tag", localImage, dockerImage)
+		cmd := exec.Command("podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "tag", localImage, dockerImage)
 		if _, err := Run(cmd); err != nil {
 			return err
 		}
 
 		// Clean up the tar file inside the container
-		if _, err := Run(exec.CommandContext(context.Background(), "podman", "exec", containerName, "rm", destPath)); err != nil {
+		if _, err := Run(exec.Command("podman", "exec", containerName, "rm", destPath)); err != nil {
 			warnError(err)
 		}
 		return nil
@@ -367,7 +356,7 @@ func LoadImageToKindClusterWithName(name string) error {
 
 	// For docker, use direct image loading
 	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
-	cmd := exec.CommandContext(context.Background(), "kind", kindOptions...)
+	cmd := exec.Command("kind", kindOptions...)
 	_, err := Run(cmd)
 	return err
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,13 +22,14 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
-	ginkgo "github.com/onsi/ginkgo/v2" //nolint:revive
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 // Constants for operator versions and URLs
@@ -45,13 +46,21 @@ const (
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
+// writeGinkgoWriterf writes formatted output to the Ginkgo writer.
+func writeGinkgoWriterf(format string, args ...any) error {
+	_, err := fmt.Fprintf(ginkgo.GinkgoWriter, format, args...)
+	return err
+}
+
 // warnError logs a warning message when an error occurs during cleanup operations.
 // This function is used for non-critical errors that shouldn't fail the test.
 //
 // Parameters:
 //   - err: The error to log as a warning
 func warnError(err error) {
-	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "warning: %v\n", err)
+	if writeErr := writeGinkgoWriterf("warning: %v\n", err); writeErr != nil {
+		return
+	}
 }
 
 // Run executes the provided command within the project context.
@@ -65,19 +74,26 @@ func warnError(err error) {
 //   - string: The combined stdout and stderr output
 //   - error: Any error that occurred during command execution
 func Run(cmd *exec.Cmd) (string, error) {
-	dir, _ := GetProjectDir()
+	dir, err := GetProjectDir()
+	if err != nil {
+		return "", err
+	}
 	cmd.Dir = dir
 
-	if err := os.Chdir(cmd.Dir); err != nil {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "chdir dir: %s\n", err)
+	if chdirErr := os.Chdir(cmd.Dir); chdirErr != nil {
+		if writeErr := writeGinkgoWriterf("chdir dir: %s\n", chdirErr); writeErr != nil {
+			return "", writeErr
+		}
 	}
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
-	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "running: %s\n", command)
+	if writeErr := writeGinkgoWriterf("running: %s\n", command); writeErr != nil {
+		return "", writeErr
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return string(output), fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
+		return string(output), fmt.Errorf("%s failed with error: (%w) %s", command, err, string(output))
 	}
 
 	return string(output), nil
@@ -94,21 +110,28 @@ func Run(cmd *exec.Cmd) (string, error) {
 //   - string: The combined stdout and stderr output
 //   - error: Any error that occurred during command execution
 func RunWithInput(cmd *exec.Cmd, input string) (string, error) {
-	dir, _ := GetProjectDir()
+	dir, err := GetProjectDir()
+	if err != nil {
+		return "", err
+	}
 	cmd.Dir = dir
 
-	if err := os.Chdir(cmd.Dir); err != nil {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "chdir dir: %s\n", err)
+	if chdirErr := os.Chdir(cmd.Dir); chdirErr != nil {
+		if writeErr := writeGinkgoWriterf("chdir dir: %s\n", chdirErr); writeErr != nil {
+			return "", writeErr
+		}
 	}
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
-	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "running: %s\n", command)
+	if writeErr := writeGinkgoWriterf("running: %s\n", command); writeErr != nil {
+		return "", writeErr
+	}
 
 	// Set up pipes for stdin, stdout, and stderr
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return "", fmt.Errorf("failed to create stdin pipe: %v", err)
+		return "", fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -116,23 +139,23 @@ func RunWithInput(cmd *exec.Cmd, input string) (string, error) {
 	cmd.Stderr = &stderr
 
 	// Start the command
-	if err := cmd.Start(); err != nil {
-		return "", fmt.Errorf("failed to start command: %v", err)
+	if startErr := cmd.Start(); startErr != nil {
+		return "", fmt.Errorf("failed to start command: %w", startErr)
 	}
 
 	// Write input to stdin
-	if _, err := stdin.Write([]byte(input)); err != nil {
-		return "", fmt.Errorf("failed to write to stdin: %v", err)
+	if _, writeErr := stdin.Write([]byte(input)); writeErr != nil {
+		return "", fmt.Errorf("failed to write to stdin: %w", writeErr)
 	}
-	if err := stdin.Close(); err != nil {
-		return "", fmt.Errorf("failed to close stdin: %v", err)
+	if closeErr := stdin.Close(); closeErr != nil {
+		return "", fmt.Errorf("failed to close stdin: %w", closeErr)
 	}
 
 	// Wait for command to complete
 	err = cmd.Wait()
 	if err != nil {
 		combinedOutput := stdout.String() + stderr.String()
-		return combinedOutput, fmt.Errorf("%s failed with error: (%v) %s", command, err, combinedOutput)
+		return combinedOutput, fmt.Errorf("%s failed with error: (%w) %s", command, err, combinedOutput)
 	}
 
 	// Return combined output
@@ -146,7 +169,7 @@ func RunWithInput(cmd *exec.Cmd, input string) (string, error) {
 //   - error: Any error that occurred during installation
 func InstallPrometheusOperator() error {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "create", "-f", url)
+	cmd := exec.CommandContext(context.Background(), "kubectl", "create", "-f", url)
 	_, err := Run(cmd)
 	return err
 }
@@ -156,7 +179,7 @@ func InstallPrometheusOperator() error {
 // Errors during uninstallation are logged as warnings since they're not critical.
 func UninstallPrometheusOperator() {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
+	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -176,7 +199,7 @@ func IsPrometheusCRDsInstalled() bool {
 		"prometheusagents.monitoring.coreos.com",
 	}
 
-	cmd := exec.Command("kubectl", "get", "crds", "-o", "custom-columns=NAME:.metadata.name")
+	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crds", "-o", "custom-columns=NAME:.metadata.name")
 	output, err := Run(cmd)
 	if err != nil {
 		return false
@@ -198,7 +221,7 @@ func IsPrometheusCRDsInstalled() bool {
 // Errors during uninstallation are logged as warnings since they're not critical.
 func UninstallCertManager() {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
+	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -213,14 +236,14 @@ func UninstallCertManager() {
 //   - error: Any error that occurred during installation
 func InstallCertManager() error {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.Command("kubectl", "apply", "-f", url)
+	cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		return err
 	}
 
 	// Wait for cert-manager-webhook to be ready, which can take time if cert-manager
 	// was re-installed after uninstalling on a cluster.
-	cmd = exec.Command("kubectl", "wait", "deployment.apps/cert-manager-webhook",
+	cmd = exec.CommandContext(context.Background(), "kubectl", "wait", "deployment.apps/cert-manager-webhook",
 		"--for", "condition=Available",
 		"--namespace", "cert-manager",
 		"--timeout", "5m",
@@ -248,7 +271,7 @@ func IsCertManagerCRDsInstalled() bool {
 	}
 
 	// Execute the kubectl command to get all CRDs
-	cmd := exec.Command("kubectl", "get", "crds")
+	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crds")
 	output, err := Run(cmd)
 	if err != nil {
 		return false
@@ -290,12 +313,12 @@ func LoadImageToKindClusterWithName(name string) error {
 		}
 
 		defer func() {
-			if err := os.Remove(tmpFile.Name()); err != nil {
-				warnError(err)
+			if removeErr := os.Remove(tmpFile.Name()); removeErr != nil {
+				warnError(removeErr)
 			}
 		}()
-		if err := tmpFile.Close(); err != nil {
-			return err
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			return closeErr
 		}
 
 		// Ensure we have both localhost/ prefixed and non-prefixed tags
@@ -305,24 +328,24 @@ func LoadImageToKindClusterWithName(name string) error {
 		}
 
 		// Tag image without localhost/ prefix
-		if _, err := Run(exec.Command("podman", "tag", podmanImage, name)); err != nil {
-			return err
+		if _, runErr := Run(exec.CommandContext(context.Background(), "podman", "tag", podmanImage, name)); runErr != nil {
+			return runErr
 		}
 
 		// Save the non-prefixed image to tar
-		if _, err := Run(exec.Command("podman", "save", "-o", tmpFile.Name(), name)); err != nil {
-			return err
+		if _, runErr := Run(exec.CommandContext(context.Background(), "podman", "save", "-o", tmpFile.Name(), name)); runErr != nil {
+			return runErr
 		}
 
 		// Copy tar into kind container
 		destPath := "/tmp/" + filepath.Base(tmpFile.Name())
 		containerName := cluster + "-control-plane"
-		if _, err := Run(exec.Command("podman", "cp", tmpFile.Name(), containerName+":"+destPath)); err != nil {
-			return err
+		if _, runErr := Run(exec.CommandContext(context.Background(), "podman", "cp", tmpFile.Name(), containerName+":"+destPath)); runErr != nil {
+			return runErr
 		}
 
 		// Import image into containerd using ctr
-		_, err = Run(exec.Command("podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "import", destPath))
+		_, err = Run(exec.CommandContext(context.Background(), "podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "import", destPath))
 		if err != nil {
 			return err
 		}
@@ -330,19 +353,21 @@ func LoadImageToKindClusterWithName(name string) error {
 		// Tag the image to remove localhost/ prefix (containerd imports with localhost/ but k8s expects docker.io/library/)
 		localImage := "localhost/" + name
 		dockerImage := "docker.io/library/" + name
-		cmd := exec.Command("podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "tag", localImage, dockerImage)
+		cmd := exec.CommandContext(context.Background(), "podman", "exec", containerName, "ctr", "-n", "k8s.io", "images", "tag", localImage, dockerImage)
 		if _, err := Run(cmd); err != nil {
 			return err
 		}
 
 		// Clean up the tar file inside the container
-		_, _ = Run(exec.Command("podman", "exec", containerName, "rm", destPath))
+		if _, err := Run(exec.CommandContext(context.Background(), "podman", "exec", containerName, "rm", destPath)); err != nil {
+			warnError(err)
+		}
 		return nil
 	}
 
 	// For docker, use direct image loading
 	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
-	cmd := exec.Command("kind", kindOptions...)
+	cmd := exec.CommandContext(context.Background(), "kind", kindOptions...)
 	_, err := Run(cmd)
 	return err
 }
@@ -396,8 +421,7 @@ func GetProjectDir() (string, error) {
 // Returns:
 //   - error: Any error that occurred during file modification
 func UncommentCode(filename, target, prefix string) error {
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // Test helper reads a caller-provided fixture file path.
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -420,16 +444,16 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
+		_, writeErr := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
+		if writeErr != nil {
+			return writeErr
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
+		if _, newlineErr := out.WriteString("\n"); newlineErr != nil {
+			return newlineErr
 		}
 	}
 
@@ -437,7 +461,6 @@ func UncommentCode(filename, target, prefix string) error {
 	if err != nil {
 		return err
 	}
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // Test helper writes fixture data back to the same caller-provided path.
 	return os.WriteFile(filename, out.Bytes(), 0644)
 }


### PR DESCRIPTION
## Summary
- expand `.golangci.yml` from a minimal config to a documented, upstream-shaped setup
- enable a smaller set of actively maintained, high-signal linters and explain each one inline
- fix the repo issues the stricter lint configuration exposed in controller, logger, and test helper code

## Verification
- `make lint-config`
- `make lint`
- `make test`

## Notes
- `make test-e2e LOCAL=true` was not runnable locally because Docker was unavailable on this machine